### PR TITLE
Implement backtracking using a iterator

### DIFF
--- a/icicle-cpu/src/lifter/mod.rs
+++ b/icicle-cpu/src/lifter/mod.rs
@@ -57,7 +57,7 @@ impl InstructionLifter {
     pub fn new() -> Self {
         Self {
             lifter: sleigh_runtime::Lifter::new(),
-            decoder: sleigh_runtime::Decoder::new(),
+            decoder: sleigh_runtime::Decoder::default(),
             decoded: sleigh_runtime::Instruction::default(),
             lifted: pcode::Block::new(),
             generate_disassembly: true,
@@ -68,7 +68,7 @@ impl InstructionLifter {
     }
 
     pub fn set_context(&mut self, context: u64) {
-        self.decoder.global_context = context;
+        self.decoder.set_context(context);
     }
 
     /// Lift a single instruction starting at `vaddr` returning the address of the next instruction,
@@ -708,7 +708,7 @@ impl BlockLifter {
             }
         }
 
-        self.current.context = self.instruction_lifter.decoder.global_context;
+        self.current.context = self.instruction_lifter.decoder.context();
         Some(self.current.next)
     }
 }

--- a/sleigh/sleigh-runtime/src/decoder.rs
+++ b/sleigh/sleigh-runtime/src/decoder.rs
@@ -138,19 +138,26 @@ impl<'a, 'b> InnerDecoder<'a, 'b> {
             table,
         );
         // info required to rever the decoder to the initial state
-        let orig_next_offset = self.state.next_offset;
-        let orig_token_stack_len = self.state.token_stack.len();
+        let initial_offset = self.state.offset;
+        let initial_next_offset = self.state.next_offset;
+        let initial_context = self.state.context;
+        let initial_global_context = self.state.global_context;
+        let initial_token_stack_len = self.state.token_stack.len();
         // try all the constructors
         for constructor_id in constructors {
             match self.decode_subtable_constructor(sleigh, inst, table, constructor_id) {
                 Some(decoded) => return Some(decoded),
                 //just backtrack and try with the next constructor
                 None => {
-                    self.state.next_offset = orig_next_offset;
-                    self.state.token_stack.truncate(orig_token_stack_len);
+                    self.state.offset = initial_offset;
+                    self.state.next_offset = initial_next_offset;
+                    self.state.context = initial_context;
+                    self.state.global_context = initial_global_context;
+                    self.state.token_stack.truncate(initial_token_stack_len);
                 }
             }
         }
+        inst.last_subtable = table;
         None
     }
 


### PR DESCRIPTION
The "match constructor" operation was returning a single matching constructor, it was modified to return a iterator over all the matching constructors.

This way is possible to backtrack the constructor matching without needing to save/restoring the current constructor offset, this logic could be handled by the `Matcher`.

Other changes was required to satisfy the borrow checker:

* Created `InnerDecoder` to handle "mut" and "non-mut" references,
* The "get_token" logic was moved to `Token`,
* Match constructors now receive raw data instead of a ref to `Decoder`.

The only change to the API was made to `Decoder::global_context` that can't be read/write directly, now it can only be accessed by `Decoder::context` and `Decoder::set_context`.