### PR TITLE
Introduce `icicle_cpu::lifter::DecodeError` for better error handling

### DIFF
--- a/icicle-cpu/src/lib.rs
+++ b/icicle-cpu/src/lib.rs
@@ -26,6 +26,7 @@ pub use crate::{
 };
 pub use icicle_mem as mem;
 pub use icicle_mem::Mmu;
+pub use lifter::DecodeError;
 
 #[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq)]
 pub struct BlockKey {
@@ -187,6 +188,7 @@ pub enum ExceptionCode {
 
     ExecViolation = 0x0401,
     SelfModifyingCode = 0x0402,
+    ExecUnaligned = 0x0404,
     OutOfMemory = 0x0501,
     AddressOverflow = 0x0502,
 
@@ -327,6 +329,18 @@ impl From<icicle_mem::MemError> for ExceptionCode {
 
             // These are errors that should be handled by the memory subsystem.
             MemError::Unallocated | MemError::Unknown => Self::UnknownError,
+        }
+    }
+}
+
+impl From<DecodeError> for ExceptionCode {
+    fn from(err: DecodeError) -> Self {
+        match err {
+            DecodeError::InvalidInstruction => ExceptionCode::InvalidInstruction,
+            DecodeError::NonExecutableMemory => ExceptionCode::ExecViolation,
+            DecodeError::BadAlignment => ExceptionCode::ExecUnaligned,
+            DecodeError::DisassemblyChanged => ExceptionCode::SelfModifyingCode,
+            DecodeError::OptimizationError => ExceptionCode::UnknownError,
         }
     }
 }

--- a/icicle-cpu/src/lib.rs
+++ b/icicle-cpu/src/lib.rs
@@ -188,7 +188,7 @@ pub enum ExceptionCode {
 
     ExecViolation = 0x0401,
     SelfModifyingCode = 0x0402,
-    ExecUnaligned = 0x0404,
+    ExecUnaligned = 0x0403,
     OutOfMemory = 0x0501,
     AddressOverflow = 0x0502,
 
@@ -238,6 +238,7 @@ impl ExceptionCode {
 
             0x0401 => Self::ExecViolation,
             0x0402 => Self::SelfModifyingCode,
+            0x0403 => Self::ExecUnaligned,
             0x0501 => Self::OutOfMemory,
             0x0502 => Self::AddressOverflow,
 

--- a/icicle-jit/src/translate/mod.rs
+++ b/icicle-jit/src/translate/mod.rs
@@ -171,7 +171,8 @@ impl VmPtr {
         let offset = VmPtr::var_offset(var);
         if var.offset == 0 {
             builder.ins().load(ty, MemFlags::trusted().with_vmctx(), self.0, offset)
-        } else {
+        }
+        else {
             builder.ins().load(ty, MemFlags::new().with_vmctx().with_notrap(), self.0, offset)
         }
     }
@@ -180,7 +181,8 @@ impl VmPtr {
         let offset = VmPtr::var_offset(var);
         if var.offset == 0 {
             builder.ins().store(MemFlags::trusted().with_vmctx(), value, self.0, offset);
-        } else {
+        }
+        else {
             builder.ins().store(MemFlags::new().with_vmctx().with_notrap(), value, self.0, offset);
         }
     }

--- a/icicle-jit/src/translate/mod.rs
+++ b/icicle-jit/src/translate/mod.rs
@@ -171,8 +171,7 @@ impl VmPtr {
         let offset = VmPtr::var_offset(var);
         if var.offset == 0 {
             builder.ins().load(ty, MemFlags::trusted().with_vmctx(), self.0, offset)
-        }
-        else {
+        } else {
             builder.ins().load(ty, MemFlags::new().with_vmctx().with_notrap(), self.0, offset)
         }
     }
@@ -181,8 +180,7 @@ impl VmPtr {
         let offset = VmPtr::var_offset(var);
         if var.offset == 0 {
             builder.ins().store(MemFlags::trusted().with_vmctx(), value, self.0, offset);
-        }
-        else {
+        } else {
             builder.ins().store(MemFlags::new().with_vmctx().with_notrap(), value, self.0, offset);
         }
     }
@@ -996,9 +994,8 @@ impl<'a> Translator<'a> {
                 let addr = self.read_zxt(*target, 8);
                 self.goto_jit_exit_external_addr(addr);
             }
-            Target::Invalid => {
-                let msg = u64::from_be_bytes(*b"inv_exit");
-                self.exit_with_exception(ExceptionCode::InvalidInstruction, msg);
+            Target::Invalid(e, addr) => {
+                self.exit_with_exception(ExceptionCode::from(*e), *addr);
             }
         }
     }

--- a/icicle-test/src/main.rs
+++ b/icicle-test/src/main.rs
@@ -186,7 +186,7 @@ fn run_bench(triple: &str, config: &TestConfig) -> anyhow::Result<()> {
             // @fixme: handle cases where there are multiple instructions in the testcase.
             lifter
                 .lift(&mut source, test.load_addr)
-                .ok_or_else(|| anyhow::format_err!("Failed to lift: {:#0x}", test.load_addr))?;
+                .map_err(|e| anyhow::format_err!("Failed to lift: {:#x}: {e:?}", test.load_addr))?;
             il_count += lifter.lifted.instructions.len();
         }
     }

--- a/icicle-test/src/tester.rs
+++ b/icicle-test/src/tester.rs
@@ -46,7 +46,7 @@ impl Tester for icicle_vm::Vm {
 
         let group = self.lift(test.load_addr);
         let mut decoded = vec![];
-        if let Some(group) = group {
+        if let Ok(group) = group {
             for block in &self.code.blocks[group.range()] {
                 for stmt in &block.pcode.instructions {
                     if let pcode::Op::InstructionMarker = stmt.op {
@@ -98,7 +98,7 @@ impl Tester for icicle_vm::Vm {
             output.push('\n');
         }
 
-        if let Some(group) = group {
+        if let Ok(group) = group {
             let lifted = icicle_vm::debug::debug_block_group(self, &group)?;
             output.push_str(&lifted);
         }

--- a/icicle-vm/src/lib.rs
+++ b/icicle-vm/src/lib.rs
@@ -21,9 +21,9 @@ use std::{
 };
 
 use icicle_cpu::{
-    lifter::{self, count_instructions, Target, DecodeError},
-    mem, BlockKey, Cpu, CpuSnapshot, Environment, ExceptionCode, InternalError, ValueSource,
-    Exception,
+    lifter::{self, count_instructions, DecodeError, Target},
+    mem, BlockKey, Cpu, CpuSnapshot, Environment, Exception, ExceptionCode, InternalError,
+    ValueSource,
 };
 use pcode::PcodeDisplay;
 
@@ -117,8 +117,8 @@ impl Vm {
     ///
     /// Note: the injector is only executed on newly lifted blocks.
     pub fn add_injector<C>(&mut self, injector: C) -> InjectorRef
-        where
-            C: CodeInjector + 'static,
+    where
+        C: CodeInjector + 'static,
     {
         // @todo: consider running the injector over all current blocks.
         let injector_id = self.injectors.len();
@@ -131,8 +131,8 @@ impl Vm {
     /// Note: Be wary of changing the behavior of the injector, sine it will _not_ re-executed on
     /// existing blocks.
     pub fn get_injector_mut<C>(&mut self, id: InjectorRef) -> Option<&mut C>
-        where
-            C: CodeInjector + 'static,
+    where
+        C: CodeInjector + 'static,
     {
         self.injectors[id].as_mut_any().downcast_mut::<C>()
     }
@@ -202,7 +202,8 @@ impl Vm {
 
                 // Clear fuel so `icount` is correct.
                 self.cpu.update_fuel(0);
-            } else {
+            }
+            else {
                 self.cpu.exception.code = ExceptionCode::InstructionLimit as u32;
             }
 
@@ -770,7 +771,7 @@ impl Vm {
 #[inline(never)]
 fn print_interpreter_enter(vm: &mut Vm, block_id: u64, offset: u64) {
     let addr = vm.code.address_of(block_id, offset);
-    eprintln!("interpreter_enter: next_addr={addr:#x}, block.id={block_id}, block.offset={offset}", );
+    eprintln!("interpreter_enter: next_addr={addr:#x}, block.id={block_id}, block.offset={offset}");
 }
 
 fn print_interpreter_exit(vm: &mut Vm) {

--- a/sleigh/sleigh-compile/src/matcher/mod.rs
+++ b/sleigh/sleigh-compile/src/matcher/mod.rs
@@ -108,10 +108,10 @@ struct MatcherOrdering {
     /// The kind of intersection
     ///
     /// - [Some(Ordering::Equal)]: both self and other set the same bits.
-    /// - [Some(Ordering::Less)]: every bit in self is set in other, but other contains bits not set in
-    ///   self.
-    /// - [Some(Ordering::Greater)]: every bit in other is set in self, but self contains bits not set
-    ///   in other.
+    /// - [Some(Ordering::Less)]: every bit in self is set in other, but other contains bits not
+    ///   set in self.
+    /// - [Some(Ordering::Greater)]: every bit in other is set in self, but self contains bits not
+    ///   set in other.
     /// - [None]: both self and other contains bits not set by the other
     pub ord: Option<Ordering>,
 }

--- a/sleigh/sleigh-runtime/src/decoder.rs
+++ b/sleigh/sleigh-runtime/src/decoder.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use crate::{
-    expr::{eval_pattern_expr, PatternExprRange, EvalPatternValue},
+    expr::{eval_pattern_expr, EvalPatternValue, PatternExprRange},
     ConstructorId, Field, TableId, Token,
 };
 


### PR DESCRIPTION
Previously it was impossible to differentiate between the following errors:

- Invalid instruction (no valid decoding)
- Non-executable memory being executed
- IP alignment error

I noticed this when I set RIP to an invalid address and the exception was `InvalidInstruction`. This is my first rust code, so please review it carefully. There are also a few other errors now, but it's unclear how to handle them. Especially the `GroupStartEndEqual` is confusing and I don't know when this would happen...