### PR TITLE
Include AtSign as token for the display segment

### DIFF
--- a/sleigh/sleigh-parse/src/parser.rs
+++ b/sleigh/sleigh-parse/src/parser.rs
@@ -1101,6 +1101,7 @@ fn parse_display_section(p: &mut Parser) -> Result<Vec<ast::DisplaySegment>, Err
             TokenKind::Ident => Some(p.parse::<ast::Ident>()?.into()),
             TokenKind::String => Some(p.parse_string()?.into()),
             TokenKind::Line => lit!(""),
+            TokenKind::AtSign => lit!("@"),
             TokenKind::Is => None,
             _ => return Err(p.error_unexpected(token, &[])),
         })


### PR DESCRIPTION
This is a solution to parse `SuperH4`, the `@` is used in various Constructors Display Segments, such:

https://github.com/NationalSecurityAgency/ghidra/blob/0d71657d052743d37ccbf5eab0e9d4253529a3e7/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc#LL464C10-L464C11