### PR TITLE
Fix jit code for sleigh round instruction

### DIFF
--- a/icicle-jit/src/translate/ops.rs
+++ b/icicle-jit/src/translate/ops.rs
@@ -582,7 +582,7 @@ pub(super) fn float_floor(trans: &mut Translator, x: Value) -> Value {
 }
 
 pub(super) fn float_round(trans: &mut Translator, x: Value) -> Value {
-    trans.builder.ins().trunc(x)
+    trans.builder.ins().nearest(x)
 }
 
 pub(super) fn int_not(trans: &mut Translator, x: Value) -> Value {


### PR DESCRIPTION
Found the fix for https://github.com/icicle-emu/icicle-emu/issues/41.

The sleigh function `round` in the ghidra docs is described as "Nearest integer to v0", but it is being executed by the cranelift function `trunc`, that is documented with "round to integral, towards negative infinity".

Fixed by using the cranelift function `nearest` instead.


