### PR TITLE
Fix issue where subpiece/truncation operation would access the wrong bytes on BE architectures

### DIFF
--- a/icicle-test/tests/m68k.ins
+++ b/icicle-test/tests/m68k.ins
@@ -1,3 +1,6 @@
 // Check that big-endian overlaps are handled correctly (D0w should overlap with the LSB of D0).
 0x0206ea [30 3c ff ff]  "move.w #-0x1,D0w"
     D0 = 0x00000001 => D0 = 0x0000ffff;
+
+0xffbda [49 c0] "extb.l D0"
+    D0 = 0x00000001 => D0 = 0x00000001;

--- a/icicle-test/tests/pcode/m68k
+++ b/icicle-test/tests/pcode/m68k
@@ -6,3 +6,7 @@ move.w #-0x1,D0w
 	VF = 0x0:1
 	CF = 0x0:1
 
+extb.l D0
+<L0> (entry=0xffbda):
+	D0 = sext(D0b)
+


### PR DESCRIPTION
Previously truncation would be applied before offset resolution causing the runtime to select a sub-register where the offset is byte-flipped for big-endian architectures. Now we keep track of the base size of the original access then resolve the correct varnode and slice the value afterwards.

Fix for: #47