### PR TITLE
Add support for dynamically computed register offsets.

### DIFF
--- a/icicle-cpu/src/trace.rs
+++ b/icicle-cpu/src/trace.rs
@@ -148,7 +148,7 @@ pub struct StoreRef(usize);
 impl StoreRef {
     #[inline]
     pub fn get_store_id(&self) -> u16 {
-        self.0 as u16 + 1
+        self.0 as u16 + pcode::RESERVED_SPACE_END
     }
 }
 

--- a/icicle-jit/src/translate/mem.rs
+++ b/icicle-jit/src/translate/mem.rs
@@ -199,7 +199,7 @@ pub(super) fn load_ram(trans: &mut Translator, guest_addr: pcode::Value, output:
     if !is_jit_supported_size(size) || trans.ctx.disable_jit_mem {
         trans.interpret(pcode::Instruction::from((
             output,
-            pcode::Op::Load(0),
+            pcode::Op::Load(pcode::RAM_SPACE),
             pcode::Inputs::one(guest_addr),
         )));
         // Check for memory exceptions.
@@ -297,7 +297,7 @@ pub(super) fn store_ram(trans: &mut Translator, guest_addr: pcode::Value, value:
     let size = value.size();
     if !is_jit_supported_size(size) || trans.ctx.disable_jit_mem {
         trans.interpret(pcode::Instruction::from((
-            pcode::Op::Store(0),
+            pcode::Op::Store(pcode::RAM_SPACE),
             pcode::Inputs::new(guest_addr, value),
         )));
         // Check for memory exceptions.

--- a/icicle-jit/src/translate/mem.rs
+++ b/icicle-jit/src/translate/mem.rs
@@ -177,10 +177,10 @@ fn splat_const(trans: &mut Translator, value: u8, ty: Type) -> Value {
     }
 }
 
-pub(super) fn load_host(trans: &mut Translator, addr: Value, size: u8) -> Value {
+fn load_host(trans: &mut Translator, addr: Value, size: u8) -> Value {
     let ty = sized_int(size);
 
-    let mut flags = MemFlags::trusted().with_heap();
+    let mut flags = MemFlags::new().with_notrap().with_heap();
     flags.set_endianness(trans.ctx.endianness);
     let mut result = trans.builder.ins().load(ty, flags, addr, 0);
 
@@ -281,8 +281,8 @@ fn load_fallback(trans: &mut Translator, output: pcode::VarNode, guest_addr: Val
     value
 }
 
-pub(super) fn store_host(trans: &mut Translator, addr: Value, mut value: Value, size: u8) {
-    let mut flags = MemFlags::trusted().with_heap();
+fn store_host(trans: &mut Translator, addr: Value, mut value: Value, size: u8) {
+    let mut flags = MemFlags::new().with_notrap().with_heap();
     flags.set_endianness(trans.ctx.endianness);
     // Setting the endianness doesn't actually do anything in x86_64 backend for cranelift
     // currently, so we manually perform a byte swap operation.

--- a/icicle-jit/src/translate/mod.rs
+++ b/icicle-jit/src/translate/mod.rs
@@ -795,7 +795,10 @@ impl<'a> Translator<'a> {
                         }
                         let ptr =
                             ctx.get_trace_store_ptr(id - pcode::RESERVED_SPACE_END, inputs[0]);
-                        let value = mem::load_host(ctx.trans, ptr, output.size);
+
+                        let load_flags = MemFlags::new().with_notrap().with_heap();
+                        let ty = sized_int(output.size);
+                        let value = ctx.trans.builder.ins().load(ty, load_flags, ptr, 0);
                         self.write(output, value);
                     }
                 },
@@ -814,7 +817,9 @@ impl<'a> Translator<'a> {
                         let ptr =
                             ctx.get_trace_store_ptr(id - pcode::RESERVED_SPACE_END, inputs[0]);
                         let value = ctx.trans.read_int(inputs[1]);
-                        mem::store_host(ctx.trans, ptr, value, inputs[1].size());
+
+                        let store_flags = MemFlags::new().with_notrap().with_heap();
+                        ctx.trans.builder.ins().store(store_flags, value, ptr, 0);
                     }
                 },
 

--- a/icicle-test/tests/pcode/powerpc
+++ b/icicle-test/tests/pcode/powerpc
@@ -17,3 +17,9 @@ beq cr7,0x1000000c
 	$U1:1 = $U3:1 & 0x1:1
 	if $U1:1 jump 0x1000000c:4
 
+mfsrin r3,r4
+<L0> (entry=0xc1000000):
+	$U1:4 = r4 >> 0x1c:4
+	$U2:4 = 0x800:4 + $U1:4
+	r3 = register[$U2:4]
+

--- a/icicle-test/tests/powerpc.ins
+++ b/icicle-test/tests/powerpc.ins
@@ -4,3 +4,8 @@
     cr7 = 2 => pc = 0x1000000c;
     cr7 = 0 => pc = 0x10000004;
 }
+
+// Dynamically computed register offsets.
+0xc1000000 [7c 60 25 26]    "mfsrin r3,r4"
+              // 0xc0000000 => sr3
+    r3 = 0, r4 = 0xc0000000, sr3 = 0x1234 => r3 = 0x1234;

--- a/sleigh/pcode/src/display.rs
+++ b/sleigh/pcode/src/display.rs
@@ -218,7 +218,11 @@ pub struct SpaceId(pub u16);
 
 impl PcodeDisplay<()> for SpaceId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, _: &()) -> std::fmt::Result {
-        write!(f, "mem.{}", self.0)
+        match self.0 {
+            crate::RAM_SPACE => f.write_str("ram"),
+            crate::REGISTER_SPACE => f.write_str("register"),
+            crate::RESERVED_SPACE_END.. => write!(f, "mem.{}", self.0),
+        }
     }
 }
 

--- a/sleigh/pcode/src/ops.rs
+++ b/sleigh/pcode/src/ops.rs
@@ -26,6 +26,15 @@ pub type StoreId = u16;
 /// The ID associated with a particular memory location.
 pub type MemId = u16;
 
+/// The memory ID associated with the RAM space.
+pub const RAM_SPACE: MemId = 0;
+
+/// The memory ID associated with the register space.
+pub const REGISTER_SPACE: MemId = 1;
+
+/// The memory ID after all reserved spaces.
+pub const RESERVED_SPACE_END: MemId = 2;
+
 /// Represents a reference to a slice of a P-code variable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VarNode {

--- a/sleigh/sleigh-compile/src/symbols.rs
+++ b/sleigh/sleigh-compile/src/symbols.rs
@@ -21,9 +21,6 @@ pub(crate) enum SymbolKind {
     UserOp,
 }
 
-pub const RAM_SPACE: u64 = 0;
-pub const REGISTER_SPACE: u64 = 1;
-
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub(crate) struct Symbol {
     pub kind: SymbolKind,
@@ -182,8 +179,8 @@ impl SymbolTable {
     ///  - The name of the space overlaps with an existing identifier.
     pub fn define_space(&mut self, space: ast::Space) -> Result<(), String> {
         let id = match space.kind {
-            ast::SpaceKind::RamSpace => RAM_SPACE,
-            ast::SpaceKind::RegisterSpace => REGISTER_SPACE,
+            ast::SpaceKind::RamSpace => pcode::RAM_SPACE,
+            ast::SpaceKind::RegisterSpace => pcode::REGISTER_SPACE,
             ast::SpaceKind::RomSpace => return Err("only ROM space not supported".into()),
         };
 
@@ -461,7 +458,7 @@ impl SymbolTable {
 #[derive(Clone, Debug)]
 pub(crate) struct RamSpace {
     /// The ID assigned to varnodes referencing this space
-    pub space_id: u64,
+    pub space_id: pcode::MemId,
 
     /// Represents the number of bytes required to reference an arbitary address in the space (i.e.
     /// size_of::<*mut u8>()))

--- a/sleigh/sleigh-runtime/src/lib.rs
+++ b/sleigh/sleigh-runtime/src/lib.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, fmt::Display};
 pub use crate::{
     decoder::{ContextModValue, Decoder, DisasmConstantValue, Instruction},
     expr::PatternExprOp,
-    lifter::Lifter,
+    lifter::{Error as LifterError, Lifter},
 };
 use crate::{
     expr::PatternExprRange,
@@ -584,8 +584,9 @@ impl pcode::PcodeDisplay<SleighData> for pcode::SpaceId {
     fn fmt(&self, f: &mut std::fmt::Formatter, _: &SleighData) -> std::fmt::Result {
         // @todo: support names for other address spaces.
         match self.0 {
-            0 => f.write_str("ram"),
-            x => write!(f, "mem.{x}"),
+            pcode::RAM_SPACE => f.write_str("ram"),
+            pcode::REGISTER_SPACE => f.write_str("register"),
+            pcode::RESERVED_SPACE_END.. => write!(f, "mem.{}", self.0),
         }
     }
 }


### PR DESCRIPTION
Support dynamically computed register offsets (e.g. `r3 = register[r4 >> 28]`) by allowing the register space to be referenced by Load/Store pcode operations.

This also includes a bug fix / potential breaking change, where trace storage buffers no longer use the same endianness as the guest architecture (instead using the same endianness as the host).

Fixes: #57