### PR TITLE
Icicle update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
@@ -42,26 +42,42 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.72"
+name = "aho-corasick"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "anyhow"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
 name = "autocfg"
@@ -71,9 +87,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -83,15 +99,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "serde",
@@ -99,35 +118,35 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
+checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -137,18 +156,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b446fd40bcc17eddd6a4a78f24315eb90afdb3334999ddfd4909985c47722442"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "cranelift"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cadd7dd6dea80b783985c0f18f0eb611c71940a517d7b179f83cc8814674fc"
+checksum = "cd9c7cc7aa5033ec21721f866cb30fa397f5efda1d0f5b74fb5a9081e2b09456"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -156,18 +175,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1380172556902242d32f78ed08c98aac4f5952aef22d3684aed5c66a5db0a6fc"
+checksum = "3c7a700bc3e2e834c81c7e9e57c6b27049172fc6156a6a406dd2265d64c30409"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037cca234e1ad0766fdfe43b527ec14e100414b4ccf4bb614977aa9754958f57"
+checksum = "35bb55da792dc46a35e6e283b02b9d6aa7f21349691f41176d8ecf4a1494b6ad"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -177,7 +196,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "log",
  "regalloc2",
  "smallvec",
@@ -186,39 +205,39 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375e6afa8b9a304999ea8cf58424414b8e55e004571265a4f0826eba8b74f18"
+checksum = "bf590672e1a7580158968898ade9c82801d6ebeaa4649d6f99f9cbb411512a8b"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca590e72ccb8da963def6e36460cce4412032b1f03c31d1a601838d305abdc39"
+checksum = "3ab16a95d8b10b72eaa8bb9f0ce0fdd013e5f225bea92f69d2dbd2424aae5381"
 
 [[package]]
 name = "cranelift-control"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2d38eea4373639f4b6236a40f69820fed16c5511093cd3783bf8491a93d9cf"
+checksum = "60448a5af01f5716877e616ec1613424fb65f427320c6e6447315966507f12da"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3173c1434af23c00e4964722cf93ca8f0e6287289bf5d52110597c3ba2ea09"
+checksum = "78689d6588f53981bf005b82d94125cc40cf9856b667bc276d1acdede400b633"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec4a3a33825062eccf6eec73e852c8773220f6e4798925e19696562948beb1f"
+checksum = "c86da6e45adc39e8d66a73d6fb782b0d7961df9e44b724246e01e515f86b1f0d"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -228,15 +247,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5146b5cea4b21095a021d964b0174cf6ff5530f83e8d0a822683c7559e360b66"
+checksum = "dcb6f70d94826074699bc350c33dab82eb6f06022a3518bb466f501569d7379e"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780229af3fd7e9bce9f71db15165835b979bdb97b844f16adb9c5645ca7ebcf"
+checksum = "a44e7985c8978bf6e27199fcdfb669264f73b6db288b50b8b00d17bf11bc6dea"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -254,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bb4aef44ff8979eccc7196b0af67fd8d51e9e0ac80e5b9046b7750215edbeb"
+checksum = "9c96995350d586ef76ffb1dbc6d4bf86604cb70bd2564a31c5ee1e1c6cf10e9d"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -265,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.98.1"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cec3717ce554d3936b2101aa8eae1a2a410bd6da0f4df698a4b008fe9cf1e9"
+checksum = "e27ec0ef4115eb9cc15be9c841085db17233403f8ed325e02bd6a9d78d6c939c"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -276,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -293,7 +312,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -303,10 +322,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "fallible-iterator"
-version = "0.2.0"
+name = "derive_more"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fixedbitset"
@@ -316,9 +362,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -326,11 +372,11 @@ dependencies = [
 
 [[package]]
 name = "gdbstub"
-version = "0.6.6"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e02bf1b1a624d96925c608f1b268d82a76cbc587ce9e59f7c755e9ea11c75c"
+checksum = "6341b3480afbb34eaefc7f92713bc92f2d83e338aaa1c44192f9c2956f4a4903"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "log",
  "managed",
@@ -340,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "gdbstub_arch"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecb536c55c43593a00dde9074dbbdb0e81ce5f20dbca921400f8779c21dea9c"
+checksum = "4e3b1357bd3203fc09a6601327ae0ab38865d14231d0b65d3143f5762cc7977d"
 dependencies = [
  "gdbstub",
  "num-traits",
@@ -350,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -361,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -372,19 +418,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -396,14 +436,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
 name = "icicle-cpu"
 version = "0.1.0"
 dependencies = [
  "addr2line",
- "bitflags 2.3.3",
+ "bitflags 2.5.0",
  "bytemuck",
  "half",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "icicle-mem",
  "object",
  "pcode",
@@ -418,10 +468,10 @@ name = "icicle-fuzzing"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 2.3.3",
+ "bitflags 2.5.0",
  "bytemuck",
  "crepe",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "icicle-vm",
  "ihex",
  "indexmap",
@@ -463,13 +513,14 @@ dependencies = [
  "quickcheck",
  "target-lexicon",
  "tracing",
+ "wasmtime-jit-debug",
 ]
 
 [[package]]
 name = "icicle-linux"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.5.0",
  "bstr",
  "bytemuck",
  "icicle-cpu",
@@ -526,19 +577,19 @@ checksum = "365a784774bb381e8c19edb91190a90d7f2625e057b55de2bc0f6b57bc779ff2"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "lazy_static"
@@ -548,18 +599,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "mach"
@@ -582,14 +636,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
@@ -602,18 +656,18 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -630,22 +684,22 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "indexmap",
  "memchr",
  "ruzstd",
@@ -653,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "overload"
@@ -665,9 +719,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pcode"
@@ -675,9 +729,9 @@ version = "0.2.0"
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -685,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "proc-macro-error"
@@ -715,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -733,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -760,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4dcbd3a2ae7fb94b5813fa0e957c6ab51bf5d0a8ee1b69e0c2d0f1e6eb8485"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
 dependencies = [
  "hashbrown 0.13.2",
  "log",
@@ -773,11 +827,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
- "regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -786,14 +843,31 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "region"
@@ -809,20 +883,21 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64",
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -831,27 +906,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "ruzstd"
-version = "0.3.1"
+name = "rustix"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "ruzstd"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
- "thiserror",
+ "derive_more",
  "twox-hash",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -870,20 +958,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -892,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -904,6 +992,9 @@ name = "sleigh-compile"
 version = "0.3.0"
 dependencies = [
  "pcode",
+ "serde",
+ "serde-xml-rs",
+ "serde_derive",
  "sleigh-parse",
  "sleigh-runtime",
 ]
@@ -922,15 +1013,15 @@ dependencies = [
 
 [[package]]
 name = "slice-group-by"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "stable_deref_trait"
@@ -957,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -968,35 +1059,35 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1004,20 +1095,19 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1025,20 +1115,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1063,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "valuable"
@@ -1086,14 +1176,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "11.0.1"
+name = "wasmtime-jit-debug"
+version = "19.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf02fedda287a409cff80ad40a7c6c0f0771e99b0cd5e2b79d9cb7ecdc1b2f4"
+checksum = "92de34217bf7f0464262adf391a9950eba440f9dfc7d3b0e3209302875c6f65f"
+dependencies = [
+ "object",
+ "rustix",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "20.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55b43e693c0beeca494d522f4850afca53cb46acf309483aef32a125276ee78"
 dependencies = [
  "cfg-if",
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "19.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffaafa5c12355b1a9ee068e9295d50c4ca0a400c721950cdae4f5b54391a2da5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1120,22 +1232,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -1144,48 +1257,74 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.7"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699d0104bcdd7e7af6d093d6c6e2d0c479b8a129ee0d1023b31d2e0c71bfdda2"
+checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]

--- a/afl-icicle-trace/Cargo.toml
+++ b/afl-icicle-trace/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.72"
-bstr = { version = "1.6.0", default-features = false }
+anyhow = "1.0.82"
+bstr = { version = "1.9.1", default-features = false }
 icicle-vm = { path = "../icicle-vm" }
 icicle-fuzzing = { path = "../icicle-fuzzing" }
 icicle-gdb = { path = "../icicle-gdb" }
-libc = "0.2.147"
-serde_json = "1.0.104"
-target-lexicon = "0.12.11"
-tracing = { version = "0.1.37", default-features = false, features = ["release_max_level_trace"] }
-tracing-subscriber = { version = "0.3.17", default-features = false, features = ["fmt", "env-filter", "ansi"] }
+libc = "0.2.153"
+serde_json = "1.0.115"
+target-lexicon = "0.12.14"
+tracing = { version = "0.1.40", default-features = false, features = ["release_max_level_trace"] }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 pcode = { path = "../sleigh/pcode" }

--- a/icicle-cpu/Cargo.toml
+++ b/icicle-cpu/Cargo.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-addr2line = "0.20.0"
-bitflags = "2.3.3"
+addr2line = "0.21.0"
+bitflags = "2.5.0"
 icicle-mem = { path = "../icicle-mem" }
 pcode = { path = "../sleigh/pcode" }
 sleigh-runtime = { path = "../sleigh/sleigh-runtime" }
-target-lexicon = "0.12.11"
-tracing = { version = "0.1.37", default-features = false }
-object = { version = "0.31.1", default-features = false, features = ["read_core", "elf", "pe"] }
-bytemuck = "1.13.1"
-hashbrown = "0.13.2"
-half = "2.3.1"
+target-lexicon = "0.12.14"
+tracing = { version = "0.1.40", default-features = false }
+object = { version = "0.32.2", default-features = false, features = ["read_core", "elf", "pe"] }
+bytemuck = "1.15.0"
+hashbrown = "0.14.3"
+half = "2.4.1"
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/icicle-cpu/src/regs.rs
+++ b/icicle-cpu/src/regs.rs
@@ -58,6 +58,8 @@ pub trait ValueSource {
             9 => DynamicValue::U72(self.read(value)),
             10 => DynamicValue::U80(self.read(value)),
             16 => DynamicValue::U128(self.read(value)),
+            // For 256 bit values, currently we only support reading the lower 128 bits
+            32 => DynamicValue::U128(self.read(value.truncate(16))),
             _ => DynamicValue::U8(0),
         }
     }
@@ -77,6 +79,9 @@ pub trait ValueSource {
             9 => self.write_var::<[u8; 9]>(var, val.zxt()),
             10 => self.write_var::<[u8; 10]>(var, val.zxt()),
             16 => self.write_var::<[u8; 16]>(var, val.zxt()),
+            // For 256 bit values, currently we only support writing to the lower 128 bits
+            32 => self.write_var::<[u8; 16]>(var.truncate(16), val.zxt()),
+
             _ => (),
         }
     }

--- a/icicle-cpu/src/utils.rs
+++ b/icicle-cpu/src/utils.rs
@@ -184,6 +184,7 @@ impl BasicInstructionSource {
             reg_init: vec![],
             on_boot: crate::cpu::generic_on_boot,
             calling_cov: crate::cpu::CallCov::default(),
+            temporaries: vec![],
             sleigh,
         };
         Self { arch, base_addr: 0, mem: vec![] }

--- a/icicle-fuzzing/Cargo.toml
+++ b/icicle-fuzzing/Cargo.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.72"
+anyhow = "1.0.82"
 icicle-vm = { path = "../icicle-vm" }
 pcode = { path = "../sleigh/pcode" }
 sleigh-runtime = { path = "../sleigh/sleigh-runtime" }
-target-lexicon = "0.12.11"
-tracing = { version = "0.1.37", default-features = false }
-serde = { version = "1.0.183", features = ["derive"] }
-ron = "0.8.0"
-bitflags = "2.3.3"
-bytemuck = { version = "1.13.1", features = ["derive"] }
+target-lexicon = "0.12.14"
+tracing = { version = "0.1.40", default-features = false }
+serde = { version = "1.0.197", features = ["derive"] }
+ron = "0.8.1"
+bitflags = "2.5.0"
+bytemuck = { version = "1.15.0", features = ["derive"] }
 ihex = "3.0.0"
 crepe = "0.1.8"
-indexmap = "1.9.3"
-hashbrown = "0.13.2"
+indexmap = "2.2.6"
+hashbrown = "0.14.3"

--- a/icicle-fuzzing/src/instrumentation/mod.rs
+++ b/icicle-fuzzing/src/instrumentation/mod.rs
@@ -74,13 +74,20 @@ impl SSARewriter {
         output
     }
 
-    pub fn get_original(&mut self, new: pcode::Value) -> (usize, pcode::Value) {
+    pub fn get_original(&self, new: pcode::Value) -> (usize, pcode::Value) {
         match new {
             pcode::Value::Var(var) => {
                 let (offset, x) = *self.new_to_old.get(&var.id).unwrap_or(&(0, var));
                 (offset, x.into())
             }
             pcode::Value::Const(_, _) => (0, new),
+        }
+    }
+
+    pub fn is_temp(&self, var: pcode::VarNode) -> bool {
+        match self.get_original(var.into()).1 {
+            pcode::Value::Var(x) => x.is_temp(),
+            pcode::Value::Const(_, _) => true,
         }
     }
 }

--- a/icicle-gdb/Cargo.toml
+++ b/icicle-gdb/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.72"
-gdbstub = "0.6.6"
-gdbstub_arch = "0.2.4"
+anyhow = "1.0.82"
+gdbstub = "0.7.1"
+gdbstub_arch = "0.3.0"
 icicle-vm = { path = "../icicle-vm" }
-num-traits = "0.2.16"
+num-traits = "0.2.18"
 pcode = { path = "../sleigh/pcode" }
-target-lexicon = "0.12.11"
-tracing = { version = "0.1.37", default-features = false }
-tracing-subscriber = { version = "0.3.17", default-features = false, features = ["fmt", "tracing-log", "env-filter", "ansi"] }
+target-lexicon = "0.12.14"
+tracing = { version = "0.1.40", default-features = false }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "tracing-log", "env-filter", "ansi"] }

--- a/icicle-gdb/src/stub.rs
+++ b/icicle-gdb/src/stub.rs
@@ -141,12 +141,13 @@ impl<T: DynamicTarget> SingleThreadBase for VmState<T> {
         &mut self,
         start_addr: <Self::Arch as Arch>::Usize,
         data: &mut [u8],
-    ) -> TargetResult<(), Self> {
+    ) -> TargetResult<usize, Self> {
         let start: u64 = num_traits::cast(start_addr).unwrap();
         if !self.vm.cpu.mem.is_regular_region(start, data.len() as u64) {
             return Err(TargetError::NonFatal);
         }
-        self.vm.cpu.mem.read_bytes(start, data, perm::NONE).map_err(|_| TargetError::NonFatal)
+        self.vm.cpu.mem.read_bytes(start, data, perm::NONE).map_err(|_| TargetError::NonFatal)?;
+        Ok(data.len())
     }
 
     fn write_addrs(

--- a/icicle-jit/Cargo.toml
+++ b/icicle-jit/Cargo.toml
@@ -9,14 +9,15 @@ doctest = false
 [dependencies]
 icicle-cpu = { path = "../icicle-cpu" }
 pcode = { path = "../sleigh/pcode" }
-target-lexicon = "0.12.11"
-tracing = { version = "0.1.37", default-features = false }
-memoffset = "0.9.0"
-cranelift = "0.98.1"
-cranelift-native = "0.98.1"
-cranelift-module = "0.98.1"
-cranelift-jit = "0.98.1"
-cranelift-codegen = { version = "0.98.1", default-features = false, features = ["std"] }
+target-lexicon = "0.12.14"
+tracing = { version = "0.1.40", default-features = false }
+memoffset = "0.9.1"
+cranelift = "0.107.0"
+cranelift-native = "0.107.0"
+cranelift-module = "0.107.0"
+cranelift-jit = "0.107.0"
+cranelift-codegen = { version = "0.107.0", default-features = false, features = ["std"] }
+wasmtime-jit-debug = { version = "19.0.1", features = ["perf_jitdump"] }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/icicle-jit/src/runtime.rs
+++ b/icicle-jit/src/runtime.rs
@@ -1,45 +1,27 @@
 use icicle_cpu::{mem::perm, Cpu, ExceptionCode};
 
-use crate::{JitFunction, VmCtx};
-
-pub fn call_jit_compilation_error() -> JitFunction {
-    unsafe extern "C" fn jit_compilation_error_fn(cpu: *mut Cpu, _: &mut VmCtx, addr: u64) -> u64 {
-        (*cpu).exception.code = ExceptionCode::JitError as u32;
-        addr
-    }
-    jit_compilation_error_fn
+pub unsafe extern "C" fn jit_compilation_error(cpu: *mut Cpu, addr: u64) -> u64 {
+    (*cpu).exception.code = ExceptionCode::JitError as u32;
+    addr
 }
 
-pub fn call_bad_lookup_error() -> JitFunction {
-    unsafe extern "C" fn bad_lookup_error_fn(cpu: *mut Cpu, _: &mut VmCtx, addr: u64) -> u64 {
-        (*cpu).exception.code = ExceptionCode::JitError as u32;
-        (*cpu).exception.value = 0x1;
-        addr
-    }
-    bad_lookup_error_fn
+pub unsafe extern "C" fn bad_lookup_error(cpu: *mut Cpu, addr: u64) -> u64 {
+    (*cpu).exception.code = ExceptionCode::JitError as u32;
+    (*cpu).exception.value = 0x1;
+    addr
 }
 
-pub fn call_address_not_translated() -> JitFunction {
-    unsafe extern "C" fn address_not_translated_fn(cpu: *mut Cpu, _: &mut VmCtx, addr: u64) -> u64 {
-        (*cpu).exception.code = ExceptionCode::CodeNotTranslated as u32;
-        (*cpu).exception.value = addr;
-        addr
-    }
-    address_not_translated_fn
+pub unsafe extern "C" fn address_not_translated(cpu: *mut Cpu, addr: u64) -> u64 {
+    (*cpu).exception.code = ExceptionCode::CodeNotTranslated as u32;
+    (*cpu).exception.value = addr;
+    addr
 }
 
-pub fn call_block_contains_breakpoint() -> JitFunction {
-    unsafe extern "C" fn block_contains_breakpoint_fn(
-        cpu: *mut Cpu,
-        _: &mut VmCtx,
-        addr: u64,
-    ) -> u64 {
-        // Exit with the `InstructionLimit` exit code this results in us exiting to the interpreter
-        // which will single step the CPU until the correct instruction.
-        (*cpu).exception.code = ExceptionCode::InstructionLimit as u32;
-        addr
-    }
-    block_contains_breakpoint_fn
+pub unsafe extern "C" fn block_contains_breakpoint(cpu: *mut Cpu, addr: u64) -> u64 {
+    // Exit with the `InstructionLimit` exit code this results in us exiting to the interpreter
+    // which will single step the CPU until the correct instruction.
+    (*cpu).exception.code = ExceptionCode::InstructionLimit as u32;
+    addr
 }
 
 #[inline(always)]

--- a/icicle-linux/Cargo.toml
+++ b/icicle-linux/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-bitflags = "2.3.3"
-bstr = { version = "1.6.0", default-features = false, features = ["std"] }
-bytemuck = "1.13.1"
+bitflags = "2.5.0"
+bstr = { version = "1.9.1", default-features = false, features = ["std"] }
+bytemuck = "1.15.0"
 icicle-cpu = { path = "../icicle-cpu" }
 sleigh-runtime = { path = "../sleigh/sleigh-runtime" }
-object = { version = "0.31.1", default-features = false, features = ["write", "read_core", "elf"] }
-tracing = { version = "0.1.37", default-features = false }
+object = { version = "0.32.2", default-features = false, features = ["write", "read_core", "elf"] }
+tracing = { version = "0.1.40", default-features = false }
 pcode = { path = "../sleigh/pcode" }
-target-lexicon = "0.12.11"
+target-lexicon = "0.12.14"

--- a/icicle-linux/src/sys/syscall.rs
+++ b/icicle-linux/src/sys/syscall.rs
@@ -3,8 +3,6 @@
 // @fixme: avoid excess allocations during syscalls.
 // @fixme: handle non-blocking file handles.
 
-use std::convert::TryInto;
-
 use bstr::ByteSlice;
 
 use icicle_cpu::{
@@ -2468,7 +2466,7 @@ pub fn getrandom<C: LinuxCpu>(ctx: &mut Ctx<C>, buf: u64, buflen: u64, flags: u6
 }
 
 pub fn sigaltstack<C: LinuxCpu>(_ctx: &mut Ctx<C>, _ss: u64, _old_ss: u64) -> LinuxResult {
-    Err(VmExit::Unimplemented.into())
+    Err(errno::ENOSYS.into())
 }
 
 pub fn rt_sigaction<C: LinuxCpu>(

--- a/icicle-mem/Cargo.toml
+++ b/icicle-mem/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-tracing = { version = "0.1.37", default-features = false }
+tracing = { version = "0.1.40", default-features = false }

--- a/icicle-mem/src/perm.rs
+++ b/icicle-mem/src/perm.rs
@@ -2,6 +2,7 @@
 pub enum MemError {
     Unallocated,
     Unmapped,
+    UnmappedRegister,
     Uninitalized,
     ReadViolation,
     WriteViolation,
@@ -21,6 +22,7 @@ impl std::str::FromStr for MemError {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
             "Unmapped" => Self::Unmapped,
+            "UnmappedRegister" => Self::UnmappedRegister,
             "Unallocated" => Self::Unallocated,
             "Uninitalized" => Self::Uninitalized,
             "ReadViolation" => Self::ReadViolation,
@@ -41,6 +43,7 @@ impl MemError {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Unmapped => "Unmapped",
+            Self::UnmappedRegister => "UnmappedRegister",
             Self::Unallocated => "Unallocated",
             Self::Uninitalized => "Uninitalized",
             Self::ReadViolation => "ReadViolation",
@@ -70,6 +73,7 @@ impl MemError {
             Self::OutOfMemory => 0x1_0009,
             Self::SelfModifyingCode => 0x1_000a,
             Self::AddressOverflow => 0x1_000b,
+            Self::UnmappedRegister => 0x1_000c,
             Self::Unknown => 0x1_FFFF,
         }
     }

--- a/icicle-mem/src/physical.rs
+++ b/icicle-mem/src/physical.rs
@@ -1,4 +1,4 @@
-use std::{cell::UnsafeCell, convert::TryInto, ptr::NonNull, rc::Rc};
+use std::{cell::UnsafeCell, ptr::NonNull, rc::Rc};
 
 use crate::{perm, MemError, MemResult};
 
@@ -10,6 +10,8 @@ pub const OFFSET_BITS: usize = 12;
 // future this may not be the case, so limit the use of this constant where possible to ease future
 // refactoring (use the `page_size` and `page_aligned` methods on PhysicalMemory instead).
 pub const PAGE_SIZE: usize = 1 << OFFSET_BITS;
+
+pub const PAGE_MASK: u64 = (PAGE_SIZE - 1) as u64;
 
 /// For testing it is useful to have a limit on the maximum number of pages that we allow, to catch
 /// memory leaks during development (we may want to make this configurable in the future)

--- a/icicle-test/Cargo.toml
+++ b/icicle-test/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.71"
+anyhow = "1.0.82"
 icicle-vm = { path = "../icicle-vm" }
 pcode = { path = "../sleigh/pcode" }
 sleigh-runtime = { path = "../sleigh/sleigh-runtime" }
-target-lexicon = "0.12.7"
-tracing = { version = "0.1.37", default-features = false }
-tracing-subscriber = { version = "0.3.17", default-features = false, features = ["fmt", "env-filter", "ansi", "tracing-log"] }
+target-lexicon = "0.12.14"
+tracing = { version = "0.1.40", default-features = false }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter", "ansi", "tracing-log"] }

--- a/icicle-test/tests/pcode/arm
+++ b/icicle-test/tests/pcode/arm
@@ -54,12 +54,10 @@ smlawteq r0,r1,r1,pc
 	$U8:1 = !ZR
 	if $U8:1 jump 0x80000004:8
 <L1>:
-	$U9:8 = 0x0:8
-	$U9:4 = r1
+	$U9:8 = zext(r1)
 	$U9:8 = $U9:8 << 0x20:1
 	$U9:8 = $U9:8 s>> 0x20:1
-	$U10:8 = 0x0:8
-	$U10:2 = $tmp0:2
+	$U10:8 = zext($tmp0:2)
 	$U10:8 = $U10:8 << 0x30:1
 	$U10:8 = $U10:8 s>> 0x30:1
 	$U13:8 = $U9:8 * $U10:8
@@ -459,7 +457,6 @@ b.w 0x8005708
 mov r7,r1
 <L0> (entry=0x8005704):
 	instruction(0x8005704)
-<L1>:
 	instruction(0x8005708)
 	r7 = r1
 
@@ -487,7 +484,7 @@ beq 0x8008c40
 	NG = tmpNG
 	OV = tmpOV
 	instruction(0x8008c4e)
-	$U1:1 = tmpZR
+	$U1:1 = ZR
 	if $U1:1 jump 0x8008c40:4
 
 mvns.w r12,r4, asr #0x15
@@ -505,7 +502,7 @@ beq 0x80003aa
 	instruction(0x800034e)
 	instruction(0x8000350)
 	$tmp0:4 = r5 s>> 0x15:4
-	$U6:1 = tmpZR == 0x0:1
+	$U6:1 = ZR == 0x0:1
 	$U5:1 = !$U6:1
 	if $U5:1 jump <L2>
 <L1>:
@@ -544,8 +541,8 @@ bx.gt lr
 	OV = tmpOV
 	instruction(0x8000ec2)
 	instruction(0x8000ec4)
-	$U4:1 = !tmpZR
-	$U5:1 = tmpNG == tmpOV
+	$U4:1 = !ZR
+	$U5:1 = NG == OV
 	$U3:1 = $U4:1 && $U5:1
 	$U2:1 = !$U3:1
 	if $U2:1 jump <L2>
@@ -612,7 +609,7 @@ bcs 0x80022b0
 	NG = tmpNG
 	OV = tmpOV
 	instruction(0x800228c)
-	$U1:1 = tmpCY
+	$U1:1 = CY
 	if $U1:1 jump 0x80022b0:4
 
 ldr.w pc,[sp],#0x8

--- a/icicle-test/tests/pcode/msp430x
+++ b/icicle-test/tests/pcode/msp430x
@@ -37,8 +37,7 @@ SUB.W R14, R15
 	SR = $U5:4 | $U6:4
 	R15_16 = R15_16 - R14_16
 	$U13:2 = R15_16
-	R15 = 0x0:4
-	R15_16 = $U13:2
+	R15 = zext(R15_16)
 	$U7:1 = R15_16 s< 0x0:2
 	$U8:4 = SR & 0xfffffffb:4
 	$U9:4 = zext($U7:1)
@@ -63,8 +62,7 @@ DEC.W R15
 	SR = $U5:4 | $U6:4
 	R15_16 = R15_16 - 0x1:2
 	$U13:2 = R15_16
-	R15 = 0x0:4
-	R15_16 = $U13:2
+	R15 = zext(R15_16)
 	$U7:1 = R15_16 s< 0x0:2
 	$U8:4 = SR & 0xfffffffb:4
 	$U9:4 = zext($U7:1)
@@ -94,8 +92,7 @@ SUBC.W #1, R14
 	$U12:2 = R14_16 - 0x1:2
 	R14_16 = $U12:2 - $U3:2
 	$U19:2 = R14_16
-	R14 = 0x0:4
-	R14_16 = $U19:2
+	R14 = zext(R14_16)
 	$U13:1 = R14_16 s< 0x0:2
 	$U14:4 = SR & 0xfffffffb:4
 	$U15:4 = zext($U13:1)
@@ -123,8 +120,7 @@ SBC.W R14
 	SR = $U8:4 | $U9:4
 	R14_16 = R14_16 - $U3:2
 	$U16:2 = R14_16
-	R14 = 0x0:4
-	R14_16 = $U16:2
+	R14 = zext(R14_16)
 	$U10:1 = R14_16 s< 0x0:2
 	$U11:4 = SR & 0xfffffffb:4
 	$U12:4 = zext($U10:1)
@@ -148,10 +144,10 @@ RETI
 	$U5:4 = zext($U4:2)
 	$U6:4 = $U2:4 & 0xf000:4
 	$U7:4 = $U6:4 << 0x4:4
-	TMP_PC = $U5:4 | $U7:4
+	tmp_pc = $U5:4 | $U7:4
 	SP = SP + 0x2:4
 	check_sr_control_bits_async($U8:4, $U3:4)
-	return TMP_PC
+	return tmp_pc
 
 RRC.B @R12
 <L0> (entry=0x0):
@@ -220,8 +216,7 @@ BIS.W #0xd8, SR
 	$U2:4 = SR
 	SR_16 = 0xd8:2 | SR_16
 	$U1:2 = SR_16
-	SR = 0x0:4
-	SR_16 = $U1:2
+	SR = zext(SR_16)
 	check_sr_control_bits($U2:4, SR)
 
 MOV.W &0x1c00, R12
@@ -232,8 +227,7 @@ JEQ 0x9a98
 	instruction(0x9a88)
 	R12_16 = ram[0x1c00:4]
 	$U1:2 = R12_16
-	R12 = 0x0:4
-	R12_16 = $U1:2
+	R12 = zext(R12_16)
 	instruction(0x9a8c)
 	$U3:4 = 0x0:4
 	$U2:1 = 0x0:1
@@ -244,8 +238,7 @@ JEQ 0x9a98
 	$U1:4 = $U7:4 & 0xffff:4
 	R13_16 = ram[$U1:4]
 	$U8:2 = R13_16
-	R13 = 0x0:4
-	R13_16 = $U8:2
+	R13 = zext(R13_16)
 	instruction(0x9a90)
 	$U1:4 = SR & 0xfffffffe:4
 	SR = $U1:4 | 0x1:4
@@ -263,7 +256,7 @@ JEQ 0x9a98
 	instruction(0x9a92)
 	$U2:4 = SR >> 0x1:4
 	$U2:4 = $U2:4 & 0x1:4
-	$U1:1 = $U8:1
+	$U1:1 = $U2:1
 	if $U1:1 jump 0x9a98:4
 
 AND.B @SP+, PC
@@ -271,8 +264,7 @@ AND.B @SP+, PC
 	$U1:4 = SR & 0xfffffeff:4
 	$U13:1 = ram[SP]
 	$U3:1 = 0x4:1 & $U13:1
-	TMP_PC = 0x0:4
-	TMP_PC:1 = $U3:1
+	tmp_pc = zext($U3:1)
 	$U5:4 = $U1:4 & 0xfffffffb:4
 	$U7:1 = $U3:1 == 0x0:1
 	$U8:4 = $U5:4 & 0xfffffffd:4
@@ -284,15 +276,14 @@ AND.B @SP+, PC
 	$U12:4 = zext($U10:1)
 	SR = $U11:4 | $U12:4
 	SP = SP + 0x2:4
-	return TMP_PC
+	return tmp_pc
 
 AND.B @R15+, R15
 <L0> (entry=0x4000):
 	$U1:4 = SR & 0xfffffeff:4
 	$U13:1 = ram[R15]
 	$U3:1 = R15_lo & $U13:1
-	R15 = 0x0:4
-	R15_lo = $U3:1
+	R15 = zext($U3:1)
 	$U4:1 = $U3:1 s< 0x0:1
 	$U5:4 = $U1:4 & 0xfffffffb:4
 	$U6:4 = zext($U4:1)
@@ -354,14 +345,14 @@ CALLA &0x24ec
 <L0> (entry=0x4000):
 	SP = SP - 0x4:4
 	ram[SP] = 0x4004:4
-	TMP_PC = ram[0x24ec:4]
-	$U2:4 = TMP_PC & 0xfffff:4
+	tmp_pc = ram[0x24ec:4]
+	$U2:4 = tmp_pc & 0xfffff:4
 	call $U2:4
 
 RETA @SP+
 <L0> (entry=0x0):
-	TMP_PC = ram[SP]
-	$U1:4 = TMP_PC & 0xfffff:4
+	tmp_pc = ram[SP]
+	$U1:4 = tmp_pc & 0xfffff:4
 	SP = SP + 0x4:4
 	return $U1:4
 
@@ -608,21 +599,20 @@ TSTA SP
 DADD.B R10, PC
 <L0> (entry=0x12):
 	$U1:4 = SR & 0xfffffffe:4
-	TMP_PC:1 = bcd_add(R10_lo, 0x14:1)
-	$U9:1 = TMP_PC:1
-	TMP_PC = 0x0:4
-	TMP_PC:1 = $U9:1
-	$U3:1 = TMP_PC:1 s< 0x0:1
+	tmp_pc:1 = bcd_add(R10_lo, 0x14:1)
+	$U9:1 = tmp_pc:1
+	tmp_pc = zext(tmp_pc:1)
+	$U3:1 = tmp_pc:1 s< 0x0:1
 	$U4:4 = $U1:4 & 0xfffffffb:4
 	$U5:4 = zext($U3:1)
 	$U5:4 = $U5:4 << 0x2:4
 	SR = $U4:4 | $U5:4
-	$U6:1 = TMP_PC:1 == 0x0:1
+	$U6:1 = tmp_pc:1 == 0x0:1
 	$U7:4 = SR & 0xfffffffd:4
 	$U8:4 = zext($U6:1)
 	$U8:4 = $U8:4 << 0x1:4
 	SR = $U7:4 | $U8:4
-	jump TMP_PC
+	jump tmp_pc
 
 MOV.B -0x1f2b(R12), &0x2063
 <L0> (entry=0x4000):
@@ -705,8 +695,7 @@ MOVX.W &0x15c, R10
 <L0> (entry=0x1000):
 	R10_16 = ram[0x15c:4]
 	$U6:2 = R10_16
-	R10 = 0x0:4
-	R10_16 = $U6:2
+	R10 = zext(R10_16)
 
 MOVX.A 0x47e8(R15), R15
 <L0> (entry=0x0):
@@ -728,8 +717,7 @@ RPT #0x7 { RLAX.W R10
 	SR = $U10:4 | $U11:4
 	R10_16 = R10_16 + R10_16
 	$U12:2 = R10_16
-	R10 = 0x0:4
-	R10_16 = $U12:2
+	R10 = zext(R10_16)
 	$U13:1 = R10_16 s< 0x0:2
 	$U14:4 = SR & 0xfffffffb:4
 	$U15:4 = zext($U13:1)
@@ -750,8 +738,7 @@ RPT #0xf { RRCX.W R13
 <L0> (entry=0x0):
 	CNT = 0xe:1
 	$U27:2 = R13_16
-	R13 = 0x0:4
-	R13_16 = $U27:2
+	R13 = zext(R13_16)
 <L1>:
 	$U6:1 = R13_16 != 0x0:2
 	$U7:4 = SR & 0x1:4
@@ -788,8 +775,7 @@ RPT #0xf { RRUX.W R13
 	$U4:4 = SR & 0xfffffffe:4
 	CNT = 0xe:1
 	$U18:2 = R13_16
-	R13 = 0x0:4
-	R13_16 = $U18:2
+	R13 = zext(R13_16)
 	$U6:4 = $U4:4 & 0xfffffeff:4
 	SR = $U6:4
 <L1>:

--- a/icicle-test/tests/pcode/x64
+++ b/icicle-test/tests/pcode/x64
@@ -458,7 +458,7 @@ CMOVZ EAX,EBX
 	$U2:1 = !ZF
 	if $U2:1 jump 0x3:8
 <L1>:
-	EAX = EBX
+	RAX = zext(EBX)
 
 CMOVZ ECX,dword ptr [RSI + -0x61b9d73e]
 <L0> (entry=0x8a):
@@ -468,7 +468,7 @@ CMOVZ ECX,dword ptr [RSI + -0x61b9d73e]
 	$U2:1 = !ZF
 	if $U2:1 jump 0x91:8
 <L1>:
-	ECX = $tmp0:4
+	RCX = zext($tmp0:4)
 
 SHL EAX,0x1
 <L0> (entry=0x12000):
@@ -806,15 +806,15 @@ LAR ECX,EDX
 
 PFMIN MM0, qword ptr [RAX]
 <L0> (entry=0x0):
-	$U1:8 = ram[RAX]
-	MM0 = PackedFloatingMIN(MM0, $U1:8)
+	$U3:8 = ram[RAX]
+	MM0 = PackedFloatingMIN(MM0, $U3:8)
 
 
 PUNPCKHDQ MM1, qword ptr [RSI]
 <L0> (entry=0x0):
 	MM1_Da = MM1_Db
-	$U1:8 = RSI + 0x4:8
-	MM1_Db = ram[$U1:8]
+	$U2:8 = RSI + 0x4:8
+	MM1_Db = ram[$U2:8]
 
 BSF EAX,EDX
 <L0> (entry=0x1000):
@@ -939,8 +939,8 @@ MOVZX EBX,word ptr [0x8277b0]
 
 MOVZX EAX,byte ptr [RSI]
 <L0> (entry=0x4003de):
-	$U1:1 = ram[RSI]
-	EAX = zext($U1:1)
+	$U2:1 = ram[RSI]
+	EAX = zext($U2:1)
 	RAX = zext(EAX)
 
 LEA RAX,[RAX + 0x10]
@@ -962,19 +962,19 @@ ADD R9,R8
 
 ADD byte ptr [RAX],AL
 <L0> (entry=0x0):
-	$U4:1 = ram[RAX]
-	CF = $U4:1 carry AL
 	$U5:1 = ram[RAX]
-	OF = $U5:1 scarry AL
+	CF = $U5:1 carry AL
 	$U6:1 = ram[RAX]
-	$U7:1 = $U6:1 + AL
-	ram[RAX] = $U7:1
-	$U8:1 = ram[RAX]
-	SF = $U8:1 s< 0x0:1
+	OF = $U6:1 scarry AL
+	$U7:1 = ram[RAX]
+	$U8:1 = $U7:1 + AL
+	ram[RAX] = $U8:1
 	$U9:1 = ram[RAX]
-	ZF = $U9:1 == 0x0:1
+	SF = $U9:1 s< 0x0:1
 	$U10:1 = ram[RAX]
-	$U2:1 = popcount($U10:1)
+	ZF = $U10:1 == 0x0:1
+	$U11:1 = ram[RAX]
+	$U2:1 = popcount($U11:1)
 	$U3:1 = $U2:1 & 0x1:1
 	PF = $U3:1 == 0x0:1
 
@@ -1652,6 +1652,7 @@ LODSD RSI
 	$U4:8 = 0x8:8 * $U3:8
 	RSI = $U2:8 - $U4:8
 	EAX = ram[$U1:8]
+	RAX = zext(EAX)
 
 LODSD.REP RSI
 <L0> (entry=0x83):
@@ -1664,6 +1665,7 @@ LODSD.REP RSI
 	$U5:8 = 0x8:8 * $U4:8
 	RSI = $U3:8 - $U5:8
 	EAX = ram[$U2:8]
+	RAX = zext(EAX)
 	RCX = RCX - 0x1:8
 	jump 0x83:8
 
@@ -1678,6 +1680,7 @@ LODSD.REPNE RSI
 	$U5:8 = 0x8:8 * $U4:8
 	RSI = $U3:8 - $U5:8
 	EAX = ram[$U2:8]
+	RAX = zext(EAX)
 	RCX = RCX - 0x1:8
 	jump 0x85:8
 
@@ -1784,7 +1787,7 @@ FILD qword ptr [RBP + -0x10]
 
 FLD qword ptr [ESP]
 <L0> (entry=0x0):
-	$U2:8 = sext(ESP)
+	$U2:8 = zext(ESP)
 	ST7 = ST6
 	ST6 = ST5
 	ST5 = ST4
@@ -1792,8 +1795,8 @@ FLD qword ptr [ESP]
 	ST3 = ST2
 	ST2 = ST1
 	ST1 = ST0
-	$U3:8 = ram[$U2:8]
-	ST0 = float2float($U3:8)
+	$U4:8 = ram[$U2:8]
+	ST0 = float2float($U4:8)
 
 FLD tword ptr [RBP + -0x80]
 <L0> (entry=0x0):
@@ -1822,9 +1825,9 @@ FLDZ
 
 FISTTP word ptr [RAX]
 <L0> (entry=0x0):
-	$U2:8 = float2float(ST0)
-	$U1:2 = float2int($U2:8)
-	ram[RAX] = $U1:2
+	$U3:8 = float2float(ST0)
+	$U2:2 = float2int($U3:8)
+	ram[RAX] = $U2:2
 	ST0 = ST1
 	ST1 = ST2
 	ST2 = ST3
@@ -1982,7 +1985,9 @@ CMPXCHG8B qword ptr [RDX + -0x3ea0fba4]
 	if ZF jump <L2>
 <L1>:
 	EDX = $tmp0[4]:4
+	RDX = zext($tmp0[4]:4)
 	EAX = $tmp0:4
+	RAX = zext(EAX)
 	jump 0x1202d:8
 <L2>:
 	$U7:8 = zext(ECX)
@@ -1993,6 +1998,7 @@ CMPXCHG8B qword ptr [RDX + -0x3ea0fba4]
 
 CMPXCHG8B qword ptr [RAX]
 <L0> (entry=0x65):
+	$tmp1:8 = RAX
 	$tmp0:8 = ram[RAX]
 	$U2:8 = zext(EDX)
 	$U3:8 = $U2:8 << 0x20:8
@@ -2002,14 +2008,16 @@ CMPXCHG8B qword ptr [RAX]
 	if ZF jump <L2>
 <L1>:
 	EDX = $tmp0[4]:4
+	RDX = zext($tmp0[4]:4)
 	EAX = $tmp0:4
+	RAX = zext(EAX)
 	jump 0x68:8
 <L2>:
 	$U7:8 = zext(ECX)
 	$U8:8 = $U7:8 << 0x20:8
 	$U9:8 = zext(EBX)
-	$U10:8 = $U8:8 | $U9:8
-	ram[RAX] = $U10:8
+	$U11:8 = $U8:8 | $U9:8
+	ram[$tmp1:8] = $U11:8
 
 CMPXCHG dword ptr [0x1010],ESI
 <L0> (entry=0x0):
@@ -2032,21 +2040,18 @@ CMPXCHG dword ptr [0x1010],ESI
 
 XADD dword ptr [0x1000],ECX
 <L0> (entry=0x0):
-	$U5:4 = ram[0x1000:8]
-	CF = $U5:4 carry ECX
-	$U6:4 = ram[0x1000:8]
-	OF = $U6:4 scarry ECX
-	$U7:4 = ram[0x1000:8]
-	$U1:4 = $U7:4 + ECX
-	ECX = ram[0x1000:8]
-	RCX = zext(ECX)
-	ram[0x1000:8] = $U1:4
-	SF = $U1:4 s< 0x0:4
-	ZF = $U1:4 == 0x0:4
-	$U2:4 = $U1:4 & 0xff:4
-	$U3:1 = popcount($U2:4)
-	$U4:1 = $U3:1 & 0x1:1
-	PF = $U4:1 == 0x0:1
+	$U1:4 = ram[0x1000:8]
+	CF = $U1:4 carry ECX
+	OF = $U1:4 scarry ECX
+	$U2:4 = $U1:4 + ECX
+	ram[0x1000:8] = $U2:4
+	SF = $U2:4 s< 0x0:4
+	ZF = $U2:4 == 0x0:4
+	$U3:4 = $U2:4 & 0xff:4
+	$U4:1 = popcount($U3:4)
+	$U5:1 = $U4:1 & 0x1:1
+	PF = $U5:1 == 0x0:1
+	RCX = zext($U1:4)
 
 POP RSP
 <L0> (entry=0x0):
@@ -2240,9 +2245,6 @@ MOV byte ptr [R11],0x0
 <L0> (entry=0x0):
 	ram[R11] = 0x0:1
 
-NOP dword ptr CS:[RAX + RAX*0x1]
-<L0> (entry=0x0):
-
 VPUNPCKLDQ XMM10, XMM7, xmmword ptr [RCX + -0x40]
 <L0> (entry=0x68):
 	$U2:8 = RCX + 0xffffffffffffffc0:8
@@ -2263,7 +2265,7 @@ TEST byte ptr [RSI],0x0
 <L0> (entry=0x11000):
 	CF = 0x0:1
 	OF = 0x0:1
-	$U5:1 = ram[RSI]
+	$U6:1 = ram[RSI]
 	SF = 0x0:1
 	ZF = 0x1:1
 	PF = 0x1:1

--- a/icicle-test/tests/pcode/x86
+++ b/icicle-test/tests/pcode/x86
@@ -1,7 +1,7 @@
 PUSH EBP
 <L0> (entry=0x0):
-	RSP = RSP - 0x4:8
-	ram[RSP] = EBP
+	ESP = ESP - 0x4:4
+	ram[ESP] = EBP
 
 XOR EDX,EDX
 <L0> (entry=0x1):
@@ -18,25 +18,23 @@ MOV EBP,ESP
 
 MOV EAX,dword ptr [EBP + 0x8]
 <L0> (entry=0x5):
-	$U2:4 = EBP + 0x8:4
-	$U1:8 = zext($U2:4)
-	EAX = ram[$U1:8]
+	$U1:4 = EBP + 0x8:4
+	EAX = ram[$U1:4]
 
 PUSH ESI
 <L0> (entry=0x8):
-	RSP = RSP - 0x4:8
-	ram[RSP] = ESI
+	ESP = ESP - 0x4:4
+	ram[ESP] = ESI
 
 MOV ESI,dword ptr [EBP + 0xc]
 <L0> (entry=0x9):
-	$U2:4 = EBP + 0xc:4
-	$U1:8 = zext($U2:4)
-	ESI = ram[$U1:8]
+	$U1:4 = EBP + 0xc:4
+	ESI = ram[$U1:4]
 
 PUSH EBX
 <L0> (entry=0xc):
-	RSP = RSP - 0x4:8
-	ram[RSP] = EBX
+	ESP = ESP - 0x4:4
+	ram[ESP] = EBX
 
 LEA EBX,[EAX + -0x1]
 <L0> (entry=0xd):
@@ -45,17 +43,15 @@ LEA EBX,[EAX + -0x1]
 
 MOVZX ECX,byte ptr [ESI + EDX*0x1]
 <L0> (entry=0x10):
-	$U2:4 = ESI + EDX
-	$U1:8 = zext($U2:4)
-	$U4:1 = ram[$U1:8]
-	ECX = zext($U4:1)
+	$U1:4 = ESI + EDX
+	$U3:1 = ram[$U1:4]
+	ECX = zext($U3:1)
 
 MOV byte ptr [EBX + EDX*0x1 + 0x1],CL
 <L0> (entry=0x14):
-	$U3:4 = 0x1:4 + EBX
-	$U2:4 = $U3:4 + EDX
-	$U1:8 = zext($U2:4)
-	ram[$U1:8] = CL
+	$U2:4 = 0x1:4 + EBX
+	$U1:4 = $U2:4 + EDX
+	ram[$U1:4] = CL
 
 ADD EDX,0x1
 <L0> (entry=0x18):
@@ -82,48 +78,46 @@ TEST CL,CL
 JNZ 0x10
 <L0> (entry=0x1d):
 	$U1:1 = !ZF
-	if $U1:1 jump 0x10:8
+	if $U1:1 jump 0x10:4
 
 POP EBX
 <L0> (entry=0x1f):
-	$U1:4 = ram[RSP]
+	$U1:4 = ram[ESP]
 	ESP = ESP + 0x4:4
 	EBX = $U1:4
 
 POP ESI
 <L0> (entry=0x20):
-	$U1:4 = ram[RSP]
+	$U1:4 = ram[ESP]
 	ESP = ESP + 0x4:4
 	ESI = $U1:4
 
 POP EBP
 <L0> (entry=0x21):
-	$U1:4 = ram[RSP]
+	$U1:4 = ram[ESP]
 	ESP = ESP + 0x4:4
 	EBP = $U1:4
 
 RET
 <L0> (entry=0x22):
-	$U1:4 = ram[RSP]
+	$U1:4 = ram[ESP]
 	ESP = ESP + 0x4:4
-	EIP = $U1:4
 	return $U1:4
 
-ADD dword ptr [ESP],0xffbfeea2
+ADD dword ptr [ESP],-0x40115e
 <L0> (entry=0x23):
-	$U4:8 = zext(ESP)
-	$U5:4 = ram[$U4:8]
+	$U5:4 = ram[ESP]
 	CF = $U5:4 carry 0xffbfeea2:4
-	$U6:4 = ram[$U4:8]
+	$U6:4 = ram[ESP]
 	OF = $U6:4 scarry 0xffbfeea2:4
-	$U7:4 = ram[$U4:8]
+	$U7:4 = ram[ESP]
 	$U8:4 = $U7:4 + 0xffbfeea2:4
-	ram[$U4:8] = $U8:4
-	$U9:4 = ram[$U4:8]
+	ram[ESP] = $U8:4
+	$U9:4 = ram[ESP]
 	SF = $U9:4 s< 0x0:4
-	$U10:4 = ram[$U4:8]
+	$U10:4 = ram[ESP]
 	ZF = $U10:4 == 0x0:4
-	$U11:4 = ram[$U4:8]
+	$U11:4 = ram[ESP]
 	$U1:4 = $U11:4 & 0xff:4
 	$U2:1 = popcount($U1:4)
 	$U3:1 = $U2:1 & 0x1:1
@@ -131,8 +125,8 @@ ADD dword ptr [ESP],0xffbfeea2
 
 CALL 0x2f
 <L0> (entry=0x2a):
-	RSP = RSP - 0x4:8
-	ram[RSP] = 0x2f:4
+	ESP = ESP - 0x4:4
+	ram[ESP] = 0x2f:4
 
 IMUL EAX,EAX,0x1010101
 <L0> (entry=0x2f):
@@ -164,13 +158,12 @@ STOSD.REP ES:EDI
 	EDI = $U3:4 - $U5:4
 	ram[$U2:4] = EAX
 	ECX = ECX - 0x1:4
-	jump 0x36:8
+	jump 0x36:4
 
-CMP EBX,dword ptr [EBP + 0xfffffff8]
+CMP EBX,dword ptr [EBP + -0x8]
 <L0> (entry=0x38):
-	$U7:4 = EBP + 0xfffffff8:4
-	$U6:8 = zext($U7:4)
-	$U1:4 = ram[$U6:8]
+	$U6:4 = EBP + 0xfffffff8:4
+	$U1:4 = ram[$U6:4]
 	CF = EBX < $U1:4
 	OF = EBX sborrow $U1:4
 	$U2:4 = EBX - $U1:4
@@ -183,10 +176,9 @@ CMP EBX,dword ptr [EBP + 0xfffffff8]
 
 PUSH dword ptr [EBP]
 <L0> (entry=0x3e):
-	$U2:8 = zext(EBP)
-	$U1:4 = ram[$U2:8]
-	RSP = RSP - 0x4:8
-	ram[RSP] = $U1:4
+	$U1:4 = ram[EBP]
+	ESP = ESP - 0x4:4
+	ram[ESP] = $U1:4
 
 MOVSD.REP ES:EDI,ESI
 <L0> (entry=0x41):
@@ -204,14 +196,14 @@ MOVSD.REP ES:EDI,ESI
 	$U10:4 = ram[$U6:4]
 	ram[$U2:4] = $U10:4
 	ECX = ECX - 0x1:4
-	jump 0x41:8
+	jump 0x41:4
 
 CALL dword ptr GS:[0x10]
 <L0> (entry=0x43):
-	$U4:8 = GS_OFFSET + 0x10:8
-	$U1:4 = ram[$U4:8]
-	RSP = RSP - 0x4:8
-	ram[RSP] = 0x4a:4
+	$U4:4 = GS_OFFSET + 0x10:4
+	$U1:4 = ram[$U4:4]
+	ESP = ESP - 0x4:4
+	ram[ESP] = 0x4a:4
 	call $U1:4
 
 MOV GS,DX
@@ -238,15 +230,14 @@ BOUND EBX,dword ptr [EAX + EAX*0x4]
 
 ARPL word ptr [EAX],DX
 <L0> (entry=0x0):
-	$U6:8 = zext(EAX)
-	$U7:2 = ram[$U6:8]
+	$U7:2 = ram[EAX]
 	$U1:2 = $U7:2 & 0x3:2
 	$U2:2 = DX & 0x3:2
 	$U3:2 = $U2:2 - $U1:2
 	ZF = 0x0:2 s< $U3:2
 	$U4:2 = zext(CF)
 	$U5:2 = $U4:2 * $U3:2
-	$U8:2 = ram[$U6:8]
+	$U8:2 = ram[EAX]
 	$U9:2 = $U8:2 + $U5:2
-	ram[$U6:8] = $U9:2
+	ram[EAX] = $U9:2
 

--- a/icicle-test/tests/x86.ins
+++ b/icicle-test/tests/x86.ins
@@ -15,12 +15,12 @@
 0x000020 [5e]                    "POP ESI";
 0x000021 [5d]                    "POP EBP";
 0x000022 [c3]                    "RET";
-0x000023 [81 04 24 a2 ee bf ff]  "ADD dword ptr [ESP],0xffbfeea2";
+0x000023 [81 04 24 a2 ee bf ff]  "ADD dword ptr [ESP],-0x40115e";
 0x00002a [e8 00 00 00 00]        "CALL 0x2f";
 0x00002f [69 c0 01 01 01 01]     "IMUL EAX,EAX,0x1010101";
 0x000035 [ab]                    "STOSD ES:EDI";
 0x000036 [f3 ab]                 "STOSD.REP ES:EDI";
-0x000038 [3b 9d f8 ff ff ff]     "CMP EBX,dword ptr [EBP + 0xfffffff8]";
+0x000038 [3b 9d f8 ff ff ff]     "CMP EBX,dword ptr [EBP + -0x8]";
 0x00003e [ff 75 00]              "PUSH dword ptr [EBP]";
 0x000041 [f3 a5]                 "MOVSD.REP ES:EDI,ESI";
 0x000043 [65 ff 15 10 00 00 00]  "CALL dword ptr GS:[0x10]";

--- a/icicle-vm/Cargo.toml
+++ b/icicle-vm/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.72"
+anyhow = "1.0.82"
 icicle-cpu = { path = "../icicle-cpu" }
 icicle-linux = { path = "../icicle-linux" }
 icicle-jit = { path = "../icicle-jit" }
 pcode = { path = "../sleigh/pcode" }
 sleigh-runtime = { path = "../sleigh/sleigh-runtime" }
 sleigh-compile = { path = "../sleigh/sleigh-compile" }
-target-lexicon = "0.12.11"
-tracing = { version = "0.1.37", default-features = false }
-object = { version = "0.31.1", default-features = false, features = ["read_core", "elf"] }
+target-lexicon = "0.12.14"
+tracing = { version = "0.1.40", default-features = false }
+object = { version = "0.32.2", default-features = false, features = ["read_core", "elf"] }
 serde-xml-rs = "0.6.0"
-serde = { version = "1.0.183", features = ["derive"] }
+serde = { version = "1.0.197", features = ["derive"] }

--- a/icicle-vm/src/msp430.rs
+++ b/icicle-vm/src/msp430.rs
@@ -1,0 +1,49 @@
+use icicle_cpu::ValueSource;
+use sleigh_runtime::SleighData;
+
+use crate::cpu::Cpu;
+
+pub struct StatusRegHandler {
+    pub cf: pcode::VarNode,
+    pub zf: pcode::VarNode,
+    pub sf: pcode::VarNode,
+    pub of: pcode::VarNode,
+    pub ie: pcode::VarNode,
+    pub sr: pcode::VarNode,
+}
+
+impl StatusRegHandler {
+    pub fn new(sleigh: &SleighData) -> Self {
+        let r = |name: &str| sleigh.get_reg(name).unwrap().var;
+        Self { cf: r("CF"), zf: r("ZF"), sf: r("SF"), of: r("OF"), ie: r("IE"), sr: r("SR") }
+    }
+}
+
+impl crate::cpu::RegHandler for StatusRegHandler {
+    fn read(&mut self, cpu: &mut Cpu) {
+        let read_bit = |var: pcode::VarNode| (cpu.read_var::<u8>(var) as u32) & 0x1;
+
+        let base_sr = cpu.read_var::<u32>(self.sr);
+
+        let sr_flags = (read_bit(self.cf))
+            | (read_bit(self.zf) << 1)
+            | (read_bit(self.sf) << 2)
+            | (read_bit(self.of) << 8)
+            | (read_bit(self.ie) << 3);
+
+        let sr = (base_sr & 0xfef0) | sr_flags;
+
+        cpu.write_var::<u32>(self.sr, sr);
+    }
+
+    fn write(&mut self, cpu: &mut Cpu) {
+        let sr = cpu.read_var::<u32>(self.sr);
+        let extract_bit = |bit: u32| ((sr >> bit) & 0x1) as u8;
+
+        cpu.write_var::<u8>(self.cf, extract_bit(0));
+        cpu.write_var::<u8>(self.zf, extract_bit(1));
+        cpu.write_var::<u8>(self.sf, extract_bit(2));
+        cpu.write_var::<u8>(self.of, extract_bit(8));
+        cpu.write_var::<u8>(self.ie, extract_bit(3));
+    }
+}

--- a/sleigh/pcode/src/helpers.rs
+++ b/sleigh/pcode/src/helpers.rs
@@ -1,9 +1,6 @@
 #[inline]
 pub fn mask(bits: u64) -> u64 {
-    if bits == 64 {
-        return u64::MAX;
-    }
-    1_u64.wrapping_shl(bits as u32).wrapping_sub(1)
+    u64::MAX >> (u64::BITS - bits as u32)
 }
 
 /// Sign-extend a value with `num_bits` to a 64-bit value

--- a/sleigh/sleigh-compile/Cargo.toml
+++ b/sleigh/sleigh-compile/Cargo.toml
@@ -7,3 +7,11 @@ edition = "2021"
 sleigh-parse = { path = "../sleigh-parse" }
 sleigh-runtime = { path = "../sleigh-runtime" }
 pcode = { path = "../pcode" }
+serde-xml-rs = { version = "0.6.0", optional = true }
+serde = { version = "1.0.197", optional = true }
+serde_derive = { version = "1.0.197", optional = true }
+
+[features]
+default = ["ldefs"]
+# Adds support for loading SLEIGH specifications with the correct context data from `.ldef` files
+ldefs = ["dep:serde-xml-rs", "dep:serde", "dep:serde_derive"]

--- a/sleigh/sleigh-compile/src/constructor/mod.rs
+++ b/sleigh/sleigh-compile/src/constructor/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use sleigh_parse::ast;
 use sleigh_runtime::{
     matcher::Constraint,
-    semantics::{Local, SemanticAction, ValueSize},
+    semantics::{Local, PcodeTmp, SemanticAction, ValueSize},
     DecodeAction, Field, PatternExprOp, Token,
 };
 
@@ -83,7 +83,7 @@ pub(crate) fn build(
 
     let disasm_actions = disasm_actions::resolve(&mut scope, &constructor.disasm_actions)?;
     let mut semantics = semantics::resolve(&mut scope, &constructor.semantics)?;
-    semantics.temporaries = scope.temporaries.len();
+    semantics.temporaries = scope.temporaries.clone();
 
     Ok(Constructor {
         table,
@@ -97,13 +97,6 @@ pub(crate) fn build(
         semantics,
         span: constructor.span,
     })
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct PcodeTmp {
-    #[allow(unused)] // Previously this was used for codegen.
-    pub name: Option<ast::Ident>,
-    pub size: Option<ValueSize>,
 }
 
 pub(crate) type FieldIndex = u32;

--- a/sleigh/sleigh-compile/src/ldef.rs
+++ b/sleigh/sleigh-compile/src/ldef.rs
@@ -1,0 +1,403 @@
+//! Code for loading SLEIGH specifications using ldefs
+
+use std::path::{Path, PathBuf};
+
+use serde_derive::Deserialize;
+use sleigh_runtime::SleighData;
+
+#[derive(Debug)]
+pub enum Error {
+    CompileError(String),
+    LanguageNotFound(String),
+    Io(PathBuf, std::io::Error),
+    ParseError(PathBuf, String),
+    ContextFieldNotFound(String),
+    UnknownRegister(String),
+    InvalidPath,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::CompileError(err) => write!(f, "Error compiling slaspec: {err}"),
+            Error::LanguageNotFound(name) => write!(f, "No matching language found for: {name}"),
+            Error::Io(path, err) => write!(f, "Error reading {}: {err}", path.display()),
+            Error::ParseError(path, err) => write!(f, "Error parsing {}: {err}", path.display()),
+            Error::UnknownRegister(name) => write!(f, "Unknown register: {name}"),
+            Error::ContextFieldNotFound(name) => {
+                write!(f, "Failed to find context field: '{name}'")
+            }
+            Error::InvalidPath => write!(f, "Path to ldef file was invalid"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+#[derive(Default)]
+pub struct CallingCov {
+    /// Varnodes of integer arguments for the calling convention.
+    pub int_args: Vec<pcode::VarNode>,
+    /// Varnodes for floating args for the calling convention.
+    pub float_args: Vec<pcode::VarNode>,
+    /// Registers left unmodified after executing the function.
+    pub unaffected: Vec<pcode::VarNode>,
+}
+
+pub struct SleighLanguage {
+    /// Processor name.
+    pub processor: String,
+    /// Endianness of the processor.
+    pub endian: Endianness,
+    /// Address size (in bits) of the processor.
+    pub size: u32,
+    /// Name of the compiler defined to the language.
+    pub compiler: Option<String>,
+    /// The parsed SLEIGH specification.
+    pub sleigh: SleighData,
+    /// The initial value of the context register.
+    pub initial_ctx: u64,
+    /// Varnode containing the program counter.
+    pub pc: pcode::VarNode,
+    /// Varnode containing the stack pointer (invalid if unknown).
+    pub sp: pcode::VarNode,
+    /// The default calling convention.
+    pub default_calling_cov: CallingCov,
+}
+
+pub fn build(
+    ldef_path: &Path,
+    lang_id: &str,
+    cspec_id: Option<&str>,
+) -> Result<SleighLanguage, Error> {
+    let ldef = LanguageDef::from_xml(ldef_path)?;
+    let language =
+        ldef.find_match(lang_id).ok_or_else(|| Error::LanguageNotFound(lang_id.into()))?;
+
+    let pspec_path = language.pspec_path(&ldef_path).ok_or(Error::InvalidPath)?;
+    let pspec: PSpec = serde_xml_rs::from_reader(
+        std::fs::File::open(&pspec_path).map_err(|err| Error::Io(pspec_path.clone(), err))?,
+    )
+    .map_err(|err| Error::ParseError(pspec_path, err.to_string()))?;
+
+    let slaspec_path = language.slaspec_path(&ldef_path).ok_or(Error::InvalidPath)?;
+    let sleigh = crate::from_path(&slaspec_path).map_err(Error::CompileError)?;
+
+    // Resolve the initial context using information from `context_data` in the processor
+    // specification.
+    let mut initial_ctx = 0_u64;
+    if let Some(context_set) = pspec.context_data.context_set {
+        for entry in &context_set.set {
+            let field = sleigh
+                .get_context_field(&entry.name)
+                .ok_or_else(|| Error::ContextFieldNotFound(entry.name.clone()))?;
+            field.field.set(&mut initial_ctx, entry.val as i64);
+        }
+    }
+
+    let get_reg = |name: &str| {
+        Ok(sleigh.get_reg(name).ok_or_else(|| Error::UnknownRegister(name.to_string()))?.var)
+    };
+
+    let pc = get_reg(&pspec.programcounter.register)?;
+
+    let mut sp = pcode::VarNode::NONE;
+
+    let mut default_calling_cov = CallingCov::default();
+
+    let mut compiler = None;
+    if let Some((name, path)) = language.cspec_path(&ldef_path, cspec_id) {
+        compiler = Some(name);
+
+        // If we have a compiler spec, we can obtain additional information about the target
+        // specification.
+        let cspec: CSpec = serde_xml_rs::from_reader(
+            std::fs::File::open(&path).map_err(|err| Error::Io(path.clone(), err))?,
+        )
+        .map_err(|err| Error::ParseError(path, err.to_string()))?;
+
+        sp = get_reg(&cspec.stackpointer.register)?;
+
+        if let Some(proto) = cspec.default_proto {
+            for input in proto.prototype.input.pentry {
+                let Location::Register(reg) = input.location
+                else {
+                    // Non-register locations ignored for now.
+                    continue;
+                };
+                match input.metatype {
+                    MetaType::Int => default_calling_cov.int_args.push(get_reg(&reg.name)?),
+                    MetaType::Float => default_calling_cov.float_args.push(get_reg(&reg.name)?),
+                }
+            }
+            for location in proto.prototype.unaffected.location {
+                let Location::Register(reg) = location
+                else {
+                    // Non-register locations ignored for now.
+                    continue;
+                };
+                default_calling_cov.unaffected.push(get_reg(&reg.name)?);
+            }
+        }
+    }
+    else {
+        // Try to set some reasonable defaults if no compiler is specified.
+        if let Some(expected_sp) =
+            sleigh.named_registers.iter().find(|x| matches!(sleigh.get_str(x.name), "sp" | "SP"))
+        {
+            sp = expected_sp.var;
+        }
+    }
+
+    Ok(SleighLanguage {
+        processor: language.processor.clone(),
+        endian: language.endian,
+        size: language.size,
+        compiler,
+        sleigh,
+        initial_ctx,
+        pc,
+        sp,
+        default_calling_cov,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct Set {
+    pub name: String,
+    pub val: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProgramCounter {
+    register: String,
+}
+
+#[allow(unused)]
+#[derive(Debug, Deserialize)]
+struct ContextSet {
+    pub space: String,
+    #[serde(rename = "$value")]
+    pub set: Vec<Set>,
+}
+
+#[allow(unused)]
+#[derive(Debug, Default, Deserialize)]
+struct ContextData {
+    context_set: Option<ContextSet>,
+    #[serde(skip)]
+    tracked_set: Vec<()>,
+}
+
+/// A SLEIGH processor specification file
+#[derive(Debug, Deserialize)]
+struct PSpec {
+    #[allow(unused)]
+    #[serde(skip)]
+    properties: Vec<()>,
+    programcounter: ProgramCounter,
+    #[serde(default)]
+    context_data: ContextData,
+    #[allow(unused)]
+    #[serde(skip)]
+    register_data: Vec<()>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StackPointer {
+    register: String,
+    #[allow(unused)]
+    space: String,
+}
+
+#[derive(Default, Debug, Deserialize)]
+enum MetaType {
+    #[default]
+    #[serde(rename = "int")]
+    Int,
+    #[serde(rename = "float")]
+    Float,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegisterDesc {
+    name: String,
+}
+
+#[allow(unused)]
+#[derive(Debug, Deserialize)]
+struct AddrDesc {
+    space: String,
+}
+
+#[allow(unused)]
+#[derive(Debug, Deserialize)]
+struct VarnodeDesc {
+    space: String,
+    offset: u64,
+    size: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Location {
+    Register(RegisterDesc),
+    #[allow(unused)]
+    VarNode(VarnodeDesc),
+    #[allow(unused)]
+    Addr(AddrDesc),
+}
+
+#[derive(Debug, Deserialize)]
+struct Pentry {
+    #[allow(unused)]
+    minsize: u32,
+    #[allow(unused)]
+    maxsize: u32,
+    #[serde(default)]
+    metatype: MetaType,
+    #[serde(rename = "$value")]
+    location: Location,
+}
+
+#[derive(Debug, Deserialize)]
+struct EntryList {
+    pentry: Vec<Pentry>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct LocationList {
+    #[serde(rename = "$value")]
+    location: Vec<Location>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Prototype {
+    input: EntryList,
+    #[allow(unused)]
+    output: EntryList,
+    #[serde(default)]
+    unaffected: LocationList,
+}
+
+#[derive(Debug, Deserialize)]
+struct DefaultProto {
+    prototype: Prototype,
+}
+
+/// A SLEIGH compiler specification file
+#[derive(Debug, Deserialize)]
+pub struct CSpec {
+    default_proto: Option<DefaultProto>,
+    stackpointer: StackPointer,
+}
+
+/// A SLEIGH language definition file.
+#[derive(Debug, Deserialize)]
+pub struct LanguageDef {
+    pub language: Vec<LanguageDesc>,
+}
+
+impl LanguageDef {
+    pub fn from_xml(path: &Path) -> Result<Self, Error> {
+        serde_xml_rs::from_reader(std::io::BufReader::new(
+            std::fs::File::open(&path).map_err(|err| Error::Io(path.into(), err))?,
+        ))
+        .map_err(|err| Error::ParseError(path.into(), err.to_string()))
+    }
+
+    // Find the language definition that best matches `id`. Prefer exact matches first, then matches
+    // with a default suffix match, then falling back to first prefix match.
+    pub fn find_match(&self, id: &str) -> Option<&LanguageDesc> {
+        let mut first_default_match = None;
+        let mut first_prefix_match = None;
+
+        for lang in &self.language {
+            if lang.id == id {
+                return Some(lang);
+            }
+
+            if lang.id.starts_with(id) {
+                if first_default_match.is_none() && lang.variant == "default" {
+                    first_default_match = Some(lang);
+                }
+                if first_prefix_match.is_none() {
+                    first_prefix_match = Some(lang);
+                }
+            }
+        }
+
+        if first_default_match.is_some() {
+            return first_default_match;
+        }
+        first_prefix_match
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CompilerDesc {
+    pub name: String,
+    pub spec: String,
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LanguageDesc {
+    pub id: String,
+    pub processor: String,
+    pub endian: Endianness,
+    pub size: u32,
+    pub variant: String,
+    pub version: String,
+    pub slafile: String,
+    pub processorspec: String,
+    pub description: String,
+    pub compiler: Vec<CompilerDesc>,
+}
+
+impl LanguageDesc {
+    pub fn pspec_path(&self, ldef_path: &Path) -> Option<PathBuf> {
+        let root = ldef_path.parent()?;
+        Some(root.join(&self.processorspec))
+    }
+
+    pub fn slaspec_path(&self, ldef_path: &Path) -> Option<PathBuf> {
+        let root = ldef_path.parent()?;
+        let filename = self.slafile.strip_suffix(".sla").unwrap_or(&self.slafile);
+        Some(root.join(format!("{filename}.slaspec")))
+    }
+
+    pub fn cspec_path(
+        &self,
+        ldef_path: &Path,
+        compiler_id: Option<&str>,
+    ) -> Option<(String, PathBuf)> {
+        let root = ldef_path.parent()?;
+        let get_path = |compiler: &CompilerDesc| (compiler.id.clone(), root.join(&compiler.spec));
+
+        if let Some(id) = compiler_id {
+            return Some(get_path(self.compiler.iter().find(|x| x.id == id)?));
+        }
+
+        // No compiler specified, see if the specification contains a default compiler.
+        if let Some(compiler) =
+            self.compiler.iter().find(|x| x.id == "default" || x.name == "default")
+        {
+            return Some(get_path(compiler));
+        }
+
+        // Otherwise just try to use gcc if available
+        if let Some(compiler) = self.compiler.iter().find(|x| x.id == "gcc" || x.name == "gcc") {
+            return Some(get_path(compiler));
+        }
+
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Endianness {
+    Little,
+    Big,
+}

--- a/sleigh/sleigh-compile/src/matcher/cases.rs
+++ b/sleigh/sleigh-compile/src/matcher/cases.rs
@@ -73,6 +73,9 @@ fn build_case_matcher(
                 (ast::ConstraintCmp::Equal, &ConstraintOperand::Constant(value)) => {
                     context.add_constraint(context_token, *field, Some(value as u64), false)?;
                 }
+                // Comparing a field with itself (no op)
+                (ast::ConstraintCmp::Equal, &ConstraintOperand::Field(rhs_field))
+                    if field == &rhs_field => {}
                 _ => {
                     context.add_constraint(context_token, *field, None, false)?;
                     complex.push(constraint.clone())
@@ -82,6 +85,9 @@ fn build_case_matcher(
                 (ast::ConstraintCmp::Equal, &ConstraintOperand::Constant(value)) => {
                     tokens.add_constraint(*token, *field, Some(value as u64), token.big_endian)?;
                 }
+                // Comparing a field with itself (no op)
+                (ast::ConstraintCmp::Equal, &ConstraintOperand::Field(rhs_field))
+                    if field == &rhs_field => {}
                 _ => {
                     tokens.add_constraint(*token, *field, None, token.big_endian)?;
                     complex.push(constraint.clone())
@@ -134,7 +140,8 @@ impl BitMatcher {
         }
         let new_mask = BitVec::from_u64(mask, token_bits).shift_start(token_offset);
 
-        let Some(value) = value else {
+        let Some(value) = value
+        else {
             // complex constrained, just add 1 to the value.
             let value_part = new_mask.and(&self.mask.not());
             self.bits = self.bits.or(&value_part);

--- a/sleigh/sleigh-compile/src/symbols.rs
+++ b/sleigh/sleigh-compile/src/symbols.rs
@@ -30,7 +30,6 @@ pub(crate) struct Symbol {
 pub type SpaceId = u32;
 pub type RegisterId = u32;
 pub type _BitRangeId = u32;
-pub type ContextFieldId = u32;
 pub type TokenId = u32;
 pub type TokenFieldId = u32;
 pub type TableId = u32;

--- a/sleigh/sleigh-parse/src/ast.rs
+++ b/sleigh/sleigh-parse/src/ast.rs
@@ -321,7 +321,7 @@ impl ParserDisplay for ConstraintExpr {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ConstraintCmp {
     Equal,
     NotEqual,
@@ -431,7 +431,7 @@ impl ParserDisplay for PatternExpr {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum PatternOp {
     Add,
     Sub,
@@ -556,7 +556,7 @@ impl ParserDisplay for JumpLabel {
 pub enum PcodeExpr {
     Ident { value: Ident },
     Integer { value: u64 },
-    AddressOf { size: Option<VarSize>, value: Ident, offset: Box<PcodeExpr> },
+    AddressOf { size: Option<VarSize>, value: Ident },
     Truncate { value: Box<PcodeExpr>, size: VarSize },
     SliceBits { value: Box<PcodeExpr>, range: Range },
     Op { a: Box<PcodeExpr>, op: PcodeOp, b: Box<PcodeExpr> },
@@ -570,9 +570,9 @@ impl ParserDisplay for PcodeExpr {
         match self {
             Self::Ident { value } => value.fmt(f, p),
             Self::Integer { value } => write!(f, "{:#0x}", value),
-            Self::AddressOf { size, value, offset } => {
+            Self::AddressOf { size, value } => {
                 let size = size.map_or(String::new(), |size| format!(":{} ", size));
-                write!(f, "&{}{} + {}", size, value.display(p), offset.display(p))
+                write!(f, "&{}{}", size, value.display(p))
             }
             Self::Truncate { value, size } => write!(f, "{}:{}", value.display(p), size),
             Self::SliceBits { value, range } => {

--- a/sleigh/sleigh-parse/src/lexer.rs
+++ b/sleigh/sleigh-parse/src/lexer.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use crate::{error::Error, Span};
 
 pub type SourceId = u32;

--- a/sleigh/sleigh-parse/src/preprocessor.rs
+++ b/sleigh/sleigh-parse/src/preprocessor.rs
@@ -135,6 +135,7 @@ pub(crate) fn handle_macro(p: &mut Parser, kind: MacroKind) -> Result<(), Error>
                     let token = p.next();
                     p.get_str(token).into()
                 }
+                TokenKind::Line => "".into(),
                 _ => return Err(token.error_unexpected(&[TokenKind::String, TokenKind::Number])),
             };
             p.expect(TokenKind::Line)?;

--- a/sleigh/sleigh-parse/src/tests/preprocessor.rs
+++ b/sleigh/sleigh-parse/src/tests/preprocessor.rs
@@ -43,6 +43,21 @@ define endian=$(ENDIAN);
     assert_eq!(result.unwrap(), "define endian = big ;");
 }
 
+#[test]
+fn define_nothing() {
+    let result = preprocess_to_string(
+        r#"
+@define ENDIAN
+@ifdef ENDIAN
+define endian=big;
+@endif
+"#,
+    );
+
+    assert_eq!(result.unwrap(), "define endian = big ;");
+}
+
+
 /// Tests that the `@define` macro works with integer values
 #[test]
 fn define_integer() {

--- a/sleigh/sleigh-runtime/src/const_eval.rs
+++ b/sleigh/sleigh-runtime/src/const_eval.rs
@@ -1,0 +1,70 @@
+/// A restricted form of constant evaluation used for disassembly time constants.
+pub fn const_eval(dst: pcode::VarNode, op: pcode::Op, inputs: &pcode::Inputs) -> Option<u64> {
+    let inputs = inputs.get();
+    if dst.size > 8 || inputs[0].size() > 8 || inputs[1].size() > 8 {
+        return None;
+    }
+
+    match (op, inputs) {
+        (pcode::Op::ZeroExtend, [pcode::Value::Const(a, _), _]) => Some(a),
+        (pcode::Op::SignExtend, [pcode::Value::Const(a, input_size), _]) => {
+            let a = pcode::sxt64(a, input_size as u64 * 8);
+            Some(a & pcode::mask(dst.size as u64 * 8))
+        }
+        (pcode::Op::IntAdd, [pcode::Value::Const(a, size), pcode::Value::Const(b, _)]) => {
+            let a = pcode::sxt64(a, size as u64 * 8);
+            let b = pcode::sxt64(b, size as u64 * 8);
+            Some(a.wrapping_add(b) & pcode::mask(size as u64 * 8))
+        }
+        (pcode::Op::IntSub, [pcode::Value::Const(a, size), pcode::Value::Const(b, _)]) => {
+            let a = pcode::sxt64(a, size as u64 * 8);
+            let b = pcode::sxt64(b, size as u64 * 8);
+            Some(a.wrapping_sub(b) & pcode::mask(size as u64 * 8))
+        }
+        (pcode::Op::IntRight, [pcode::Value::Const(a, size), pcode::Value::Const(b, _)]) => {
+            if b >= size as u64 * 8 {
+                return Some(0);
+            }
+            let a = pcode::sxt64(a, size as u64 * 8);
+            Some((a >> b) & pcode::mask(size as u64 * 8))
+        }
+        (pcode::Op::IntLeft, [pcode::Value::Const(a, size), pcode::Value::Const(b, _)]) => {
+            if b >= size as u64 * 8 {
+                return Some(0);
+            }
+            Some((a << b) & pcode::mask(size as u64 * 8))
+        }
+        (pcode::Op::IntMul, [pcode::Value::Const(a, size), pcode::Value::Const(b, _)]) => {
+            let a = pcode::sxt64(a, size as u64 * 8);
+            let b = pcode::sxt64(b, size as u64 * 8);
+            Some(a.wrapping_mul(b) & pcode::mask(size as u64 * 8))
+        }
+        (pcode::Op::IntAnd, [pcode::Value::Const(a, _), pcode::Value::Const(b, _)]) => Some(a & b),
+        (pcode::Op::IntEqual, [pcode::Value::Const(a, _), pcode::Value::Const(b, _)]) => {
+            Some(if a == b { 1 } else { 0 })
+        }
+        (pcode::Op::IntNotEqual, [pcode::Value::Const(a, _), pcode::Value::Const(b, _)]) => {
+            Some(if a != b { 1 } else { 0 })
+        }
+        (pcode::Op::IntLess, [pcode::Value::Const(a, _), pcode::Value::Const(b, _)]) => {
+            Some(if a < b { 1 } else { 0 })
+        }
+        (pcode::Op::IntLessEqual, [pcode::Value::Const(a, _), pcode::Value::Const(b, _)]) => {
+            Some(if a <= b { 1 } else { 0 })
+        }
+        (pcode::Op::BoolAnd, [pcode::Value::Const(a, _), pcode::Value::Const(b, _)]) => {
+            Some(if a != 0 && b != 0 { 1 } else { 0 })
+        }
+        (pcode::Op::BoolNot, [pcode::Value::Const(a, _), _]) => Some(if a == 0 { 1 } else { 0 }),
+        (pcode::Op::IntNot, [pcode::Value::Const(a, size), _]) => {
+            Some(!a & pcode::mask(size as u64 * 8))
+        }
+        // x OP 0 == 0 identities.
+        (
+            pcode::Op::BoolAnd | pcode::Op::IntAnd | pcode::Op::IntMul,
+            [pcode::Value::Const(0, _), _] | [_, pcode::Value::Const(0, _)],
+        ) => Some(0),
+
+        _ => None,
+    }
+}

--- a/sleigh/sleigh-runtime/src/debug.rs
+++ b/sleigh/sleigh-runtime/src/debug.rs
@@ -11,10 +11,14 @@ impl std::fmt::Debug for SubtableCtx<'_, '_> {
             .get(constructor_id as usize)
             .map_or("unknown", |x| x.line.as_str());
 
+        let name =
+            self.data.debug_info.subtable_names.get(constructor.table as usize).unwrap_or(&(0, 0));
         f.debug_struct("Subtable")
-            .field("id", &constructor.table)
-            .field("constructor", &constructor_id)
-            .field("constructor_line", &constructor_line)
+            .field("id", &format_args!("{} (\"{}\")", constructor.table, &self.data.get_str(*name)))
+            .field("constructor_id", &constructor_id)
+            .field("offset", &self.constructor.offset)
+            .field("len", &self.constructor.len)
+            .field("line", &constructor_line)
             .field("locals", &LocalsDebug { ctx: self, locals: self.locals() })
             .field("subtables", &SubtableListDebug { ctx: self, list: self.subtables() })
             .finish()
@@ -42,6 +46,10 @@ struct LocalsDebug<'a, 'b> {
 
 impl std::fmt::Debug for LocalsDebug<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_list().entries(self.locals.iter()).finish()
+        let mut list = f.debug_list();
+        for entry in self.locals {
+            list.entry(&format_args!("{entry:#x}"));
+        }
+        list.finish()
     }
 }

--- a/sleigh/sleigh-runtime/src/expr.rs
+++ b/sleigh/sleigh-runtime/src/expr.rs
@@ -3,7 +3,7 @@ pub type PatternExprRange = (u32, u32);
 pub use sleigh_parse::ast::PatternOp;
 
 /// Encodes an operation that is part of a pattern expression.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PatternExprOp<T> {
     Value(T),
     Constant(u64),

--- a/sleigh/sleigh-runtime/src/matcher.rs
+++ b/sleigh/sleigh-runtime/src/matcher.rs
@@ -47,7 +47,7 @@ impl SequentialMatcher {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MatchCase {
     /// The constructor id of the matched constructor.
     pub constructor: ConstructorId,
@@ -79,7 +79,7 @@ impl MatchCase {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
 pub struct Pattern {
     pub bits: u64,
     pub mask: u64,
@@ -95,14 +95,14 @@ impl Pattern {
 ///
 /// Note: Since full expressions are almost never used by real-world SLEIGH specifications we have
 /// special cases for constants, and field expressions to improve performance.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ConstraintOperand {
     Constant(i64),
     Field(Field),
     Expr(Vec<PatternExprOp<Field>>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Constraint {
     Token { token: Token, field: Field, cmp: ConstraintCmp, operand: ConstraintOperand },
     Context { field: Field, cmp: ConstraintCmp, operand: ConstraintOperand },

--- a/sleigh/sleigh-runtime/src/semantics.rs
+++ b/sleigh/sleigh-runtime/src/semantics.rs
@@ -3,7 +3,7 @@ pub type ValueSize = u16;
 #[derive(Debug, Clone)]
 pub enum SemanticAction {
     Op { op: pcode::Op, inputs: Vec<Value>, output: Option<Value> },
-    AddressOf { output: Value, base: Local, offset: Value },
+    AddressOf { output: Value, base: Local },
     LoadRegister { pointer: Value, output: Value, size: ValueSize },
     StoreRegister { pointer: Value, value: Value, size: ValueSize },
     DelaySlot,
@@ -68,6 +68,12 @@ impl Export {
             Self::RegisterRef(_, size) => Some(*size),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct PcodeTmp {
+    pub name: Option<sleigh_parse::ast::Ident>,
+    pub size: Option<ValueSize>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
### Breaking changes

- Renamed `ExceptionCode::DivideByZero` -> `ExceptionCode::DivisionException`.
- `MemError`: Added variant for representing errors that can occur when accessing dynamic registers.
- `DecoderError`: Change enum variants to support returning full lifter information on decode error.
- `PcodeOpInjector`: Change trait to take an `Arch` argument (instead of `InstructionSource`).
- `ReadHook` to support returning a value (instead of loading the original target).
- Rework the way SLEIGH information is loaded. Target triples are now mapped to SLEIGH `ldef` identifiers which may change some processor configuration. e.g.,  _i686_ target will now use the `x86.slaspec` instead of the `x86-64.slaspec` (with the appropriate context bits set).

### Enhancements

- SLEIGH: Add support for extracting data from 256-bit (or larger) registers using shift, zext and OR operations.
- SLEIGH: Better support for dynamic register offsets (closes: #30).
- SLEIGH: Report an error when attempting to access an unmapped dynamic register.
- SLEIGH: Avoid allocating field slots for writes to context fields.
- SLEIGH: Introduce basic constant evaluator during lifting to increase the chance a dynamic register access can be mapped at disassembly time.
- SLEIGH: Improve decode debug output.
- SLEIGH: Expose several configuration options to control decoder runtime.
- JIT: Update Cranelift version.
- JIT: Move JIT context inside of Cpu struct to avoid needing to pass an extra parameter on JIT entry.
- JIT: Add function for dumping perf compatible debug info for JIT (via `wasmtime-jit-debug`).
- JIT: Minor TLB-lookup optimizations.
- Core: Add support for storing typed data in the CPU context. (see: `icicle-fuzzing/src/trace.rs` changes for usage examples).
- Core: Clean optimizer code.
- Core: Check for zero-extension idioms and attempt to normalize them (simplifies later analysis).
- Core: Minor performance optimization for memory mapping.
- Core: Fix redundant import warnings.
- Emulation: Improve support for saturating operations (e.g., for arm32 targets).
- Emulation: Introduce rewrite operations to support: Unsigned int-to-float conversions, comparisons with non natively sized values.
- Instrumentation: Make CmpFinder more robust to bit-packed flags, and prefer comparisons involving ISA-registers (rather than temporaries that alias the original register).

### Bug fixes

- **(major)** JIT: Fix issue where the JIT failed to properly invalidate a cached copy of a varnode in a Cranelift variable, if the destination varnode was a non-power-of-two slice of larger varnode used in the same block.
- JIT: Fix issue where the varnode holding program counter (this only affects SLEIGH specifications that incorrectly reference the PC varnode, instead of inst_start or inst_next).
- JIT/Interpreter: Check for division overflow perform executing signed division instructions.
- SLEIGH: Better handle register offsets for big-endian architectures.
    - Fixes: #59
    - Fixes and issue where large varnodes (>128-bit) would be modelled incorrectly for big-endian architectures.
- SLEIGH: Treat `field=field` complex constraints as `epsilon` constraints (fixes constraint ordering in x86-32 specification).
- SLEIGH: Check for ending semi-colons in disassembly actions section.
- SLEIGH: Support `@define` statements with no value.
- SLEIGH: Fix handling of `...` in rare cases where it appears before a smaller subtable that has nested `;` values.
- Emulation: Ensure high bits are copied for `pshuflw` instructions.
- Core: Fix optimization error related to dead-code elimination that is performed on internal blocks.