### PR TITLE
Allow modifying the Mmu capacity

### DIFF
--- a/icicle-mem/src/mmu.rs
+++ b/icicle-mem/src/mmu.rs
@@ -268,6 +268,16 @@ impl Mmu {
         self.physical.allocated_pages()
     }
 
+    #[allow(unused)]
+    pub fn capacity(&self) -> usize {
+        self.physical.capacity()
+    }
+
+    #[allow(unused)]
+    pub fn set_capacity(&mut self, new_capacity: usize) -> bool {
+        self.physical.set_capacity(new_capacity)
+    }
+
     /// Read bytes from `addr` checking that the permissions specified by `perm` are set
     pub fn read_bytes(&mut self, mut addr: u64, buf: &mut [u8], perm: u8) -> MemResult<()> {
         if buf.len() > 16 {

--- a/icicle-mem/src/physical.rs
+++ b/icicle-mem/src/physical.rs
@@ -87,7 +87,7 @@ impl PhysicalMemory {
             Some(index) => index,
             None => {
                 if self.allocated.len() >= self.capacity {
-                    tracing::warn!("Guest exceeded memory limit");
+                    tracing::warn!("Guest exceeded memory limit {}", self.capacity);
                     return None;
                 }
                 self.allocated.push(Page::new());
@@ -96,6 +96,19 @@ impl PhysicalMemory {
         };
         self.allocated[index.0 as usize].clear();
         Some(index)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn set_capacity(&mut self, new_capacity: usize) -> bool {
+        if self.allocated.len() >= new_capacity {
+            tracing::warn!("Failed to reduce capacity below allocated size");
+            return false;
+        }
+        self.capacity = new_capacity;
+        return true
     }
 
     #[allow(unused)] // @fixme: This should be called when we unmap pages


### PR DESCRIPTION
Currently the maximum capacity of 50k pages is hardcoded, this function allows a user to expand the capacity as-necessary (without breaking the current interface).