### PR TITLE
Improvements to debugging and JIT optimizations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
- "gimli 0.31.0",
+ "gimli",
  "memmap2",
  "object",
  "rustc-demangle",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887c33ddd83c52e1381c0f85e9db95425a9a62d9f7a73234141d5df25352ae43"
+checksum = "61fcb428a7799e67267ed1ea29d5903b87bec745f44c3decc5c621e97b9b7105"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -166,24 +166,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5264b5d315c515e0845dcd2cc1697ea0018d739d58b47477f8455842583568"
+checksum = "8ea5e7afe85cadb55c4c1176268a2ac046fdff8dfaeca39e18581b9dc319ca9e"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2797648025a7b2e32ec49fb2f71655fed74453cd41e209c6e39fd3107654f8"
+checksum = "8ab25ef3be935a80680e393183e1f94ef507e93a24a8369494d2c6818aedb3e3"
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "548a3af0d36a36bab5c6a3bb8684816d501fd012c3328beb0f57dbbcb364c479"
+checksum = "900a19b84545924f1851cbfe386962edfc4ecbc3366a254825cf1ecbcda8ba08"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -193,7 +193,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.29.0",
+ "gimli",
  "hashbrown",
  "log",
  "regalloc2",
@@ -204,42 +204,42 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9001ad2a4893d3505be514d3b55acc6d7efecba4bcc9ab6a7c4d422765c84202"
+checksum = "08c73b2395ffe9e7b4fdf7e2ebc052e7e27af13f68a964985346be4da477a5fc"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4b34c22fdfd5d95287ae0cc766e962a976754f0cf7daa4bfa5c6af55c5fb6b"
+checksum = "7d9ed0854e96a4ff0879bff39d078de8dea7f002721c9494c1fdb4e1baa86ccc"
 
 [[package]]
 name = "cranelift-control"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d78c20a5ba56200e691e0a62d15ffd18ffc781064443acbadce1f7dc847917"
+checksum = "b4aca921dd422e781409de0129c255768fec5dec1dae83239b497fb9138abb89"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e9d6c799b0775d43211d983b5f9230ea604063003cb6d492daf8dcac51da9b"
+checksum = "e2d770e6605eccee15b49decdd82cd26f2b6404767802471459ea49c57379a98"
 dependencies = [
  "cranelift-bitset",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1bd2fdbe0c0c10fcee7826c00ea0e7b2a0c4e95e6a879d88e11c006587560f"
+checksum = "29268711cb889cb39215b10faf88b9087d4c9e1d2633581e4f722a2bf4bb4ef9"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -249,15 +249,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12b357f51e34f8e271977a5f422940aa985943d14ee8d49f66c6459ef458511"
+checksum = "dc65156f010aed1985767ad1bff0eb8d186743b7b03e23d0c17604a253e3f356"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d4fa37bb9bc596943ae5e21be01e65ee4c5453df646c8f6e74e6f6a81d00a0"
+checksum = "40ba6b46367a4f466cfb1abe32793fa1a0f96d862251491b01a44726b8ed9445"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -270,14 +270,14 @@ dependencies = [
  "region",
  "target-lexicon",
  "wasmtime-jit-icache-coherence",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544c9993ed35cb20d6d5bf6fd8bf59304c925606c6439e13273fcbb370b5af0d"
+checksum = "007607022a4883ebdffc46c0925e2e10babf2a565ae78518034ade722aa825d2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da80e271413343c8ca2ca3375360a8d486355063bf96547db9714f2ac4580629"
+checksum = "d8bf9b361eaf5a7627647270fabf1dc910d993edbeaf272a652c107861ebe9c2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -336,7 +336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -398,17 +398,6 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
-dependencies = [
- "fallible-iterator",
- "indexmap",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
@@ -446,7 +435,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.6.0",
  "bytemuck",
- "gimli 0.31.0",
+ "gimli",
  "half",
  "icicle-mem",
  "object",
@@ -611,10 +600,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "mach"
-version = "0.3.2"
+name = "mach2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
@@ -866,14 +855,14 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "region"
-version = "2.2.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
- "mach",
- "winapi",
+ "mach2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -910,7 +899,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1176,9 +1165,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109dcbe0367eeda5467ea2950ff81899dab3ee362220eadcae0691d336122d29"
+checksum = "077d8382176594ded9e7d837db2f320b45915d40b99f4319b2bd1061bbdf5f4f"
 dependencies = [
  "object",
  "rustix",
@@ -1187,21 +1176,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67e6379ff6f5eb316e4fe2baaf360c7871082006fc31addf3cf58011edb855c"
+checksum = "6e458e6a1a010a53f86ac8d75837c0c6b2ce3e54b7503b2f1dc5629a4a541f5a"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467bf568f44048477d865a7bb42a1876acd1e2d3de77b42307f5d8e0126fc241"
+checksum = "abe01058e422966659e1af00af833147d54658b07c7e74606d73ca9af3f1690a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1235,6 +1224,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,10 +19,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "afl-icicle-trace"
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arbitrary"
@@ -120,29 +120,23 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
+checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -152,18 +146,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "cranelift"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f302c41dd8e79fc7928bb3f0b2e4a64fb8fffa3f234f7f6eec6391b9604158d"
+checksum = "887c33ddd83c52e1381c0f85e9db95425a9a62d9f7a73234141d5df25352ae43"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -172,24 +166,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effa84ab2023f7138045ece6b326588c17447ca22e66db71ec15cb0a6c0c4ad2"
+checksum = "ad5264b5d315c515e0845dcd2cc1697ea0018d739d58b47477f8455842583568"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a1dfc50dca188a15d938867c4400589530bcb0138f7022aae6d059d1d8c309"
+checksum = "6c2797648025a7b2e32ec49fb2f71655fed74453cd41e209c6e39fd3107654f8"
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821c20c639350158ecca928dc2a244d0d1c9cef2377a378fc62a445a286eb1ca"
+checksum = "548a3af0d36a36bab5c6a3bb8684816d501fd012c3328beb0f57dbbcb364c479"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -199,8 +193,8 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.28.1",
- "hashbrown 0.14.5",
+ "gimli 0.29.0",
+ "hashbrown",
  "log",
  "regalloc2",
  "rustc-hash",
@@ -210,42 +204,42 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064473f2fd59b44fa2c9aaa60de1f9c44db5e13521e28bc85d2b92ee535ef625"
+checksum = "9001ad2a4893d3505be514d3b55acc6d7efecba4bcc9ab6a7c4d422765c84202"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f39b9ebfd2febdc2acfb9a0fca110665bcd5a6839502576307735ed07b2177"
+checksum = "df4b34c22fdfd5d95287ae0cc766e962a976754f0cf7daa4bfa5c6af55c5fb6b"
 
 [[package]]
 name = "cranelift-control"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e125c189c3a1ca8dfe209fc6f46edba058a6d24e0b92aff69459a15f4711e7"
+checksum = "a4d78c20a5ba56200e691e0a62d15ffd18ffc781064443acbadce1f7dc847917"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea62eb109baec2247e1a6fa7b74c0f584b1e76e289cfd7017385b4b031fc8450"
+checksum = "67e9d6c799b0775d43211d983b5f9230ea604063003cb6d492daf8dcac51da9b"
 dependencies = [
  "cranelift-bitset",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722b089357aacb6c7528b2e59a5fe00917d61ce63448b25a3e477a5b7819fac8"
+checksum = "7c1bd2fdbe0c0c10fcee7826c00ea0e7b2a0c4e95e6a879d88e11c006587560f"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -255,15 +249,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b5005a48288e7fc2a2991a377831c534e26929b063c379c018060727785a9b"
+checksum = "e12b357f51e34f8e271977a5f422940aa985943d14ee8d49f66c6459ef458511"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f843932baf8d1025c5f114b929eda172d74b7163d058e0de2597c308b567c7e9"
+checksum = "58d4fa37bb9bc596943ae5e21be01e65ee4c5453df646c8f6e74e6f6a81d00a0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -281,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449819ef1c4af139cf1b9717916fcaea0e23248853d3e95135139773a842d3eb"
+checksum = "544c9993ed35cb20d6d5bf6fd8bf59304c925606c6439e13273fcbb370b5af0d"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -292,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.110.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae2d48f38081a9e679ad795bd36bb29bedeb5552fc1c195185bf9885fa1b16e"
+checksum = "da80e271413343c8ca2ca3375360a8d486355063bf96547db9714f2ac4580629"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -320,7 +314,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -359,9 +353,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -369,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "gdbstub"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6341b3480afbb34eaefc7f92713bc92f2d83e338aaa1c44192f9c2956f4a4903"
+checksum = "fbcc892208d6998fb57e7c3e05883def66f8130924bba066beb0cfe71566a9f6"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -383,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "gdbstub_arch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3b1357bd3203fc09a6601327ae0ab38865d14231d0b65d3143f5762cc7977d"
+checksum = "328a9e9425db13770d0d11de6332a608854266e44c53d12776be7b4aa427e3de"
 dependencies = [
  "gdbstub",
  "num-traits",
@@ -404,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -432,15 +426,6 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -587,12 +572,12 @@ checksum = "365a784774bb381e8c19edb91190a90d7f2625e057b55de2bc0f6b57bc779ff2"
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -609,9 +594,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "linux-raw-sys"
@@ -657,9 +642,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
@@ -675,11 +660,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -703,13 +688,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown 0.14.5",
+ "hashbrown",
  "indexmap",
  "memchr",
  "ruzstd",
@@ -797,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -824,11 +809,11 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.9.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown",
  "log",
  "rustc-hash",
  "slice-group-by",
@@ -837,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -911,15 +896,15 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -930,11 +915,10 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5022b253619b1ba797f243056276bed8ed1a73b0f5a7ce7225d524067644bf8f"
+checksum = "99c3938e133aac070997ddc684d4b393777d293ba170f2988c8fd5ea2ad4ce21"
 dependencies = [
- "byteorder",
  "twox-hash",
 ]
 
@@ -946,9 +930,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -967,20 +951,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -1057,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1068,28 +1052,28 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1168,9 +1152,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "valuable"
@@ -1192,9 +1176,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "23.0.1"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71632cb3d01bc456b010689c554caf0f36e9040ffd357f097fdb8d42d09f710"
+checksum = "109dcbe0367eeda5467ea2950ff81899dab3ee362220eadcae0691d336122d29"
 dependencies = [
  "object",
  "rustix",
@@ -1203,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "23.0.1"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fddf3e2980fb1d123d1fcac55189e417fdd3dba4f62139b5a0a1f9efe5669d5"
+checksum = "a67e6379ff6f5eb316e4fe2baaf360c7871082006fc31addf3cf58011edb855c"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1215,13 +1199,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "23.0.1"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b40c6d9c8f56ea0cbeacb80f40075a91687163b693b7cda39b48efe3c974d2"
+checksum = "467bf568f44048477d865a7bb42a1876acd1e2d3de77b42307f5d8e0126fc241"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1321,9 +1305,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
+checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
 
 [[package]]
 name = "zerocopy"
@@ -1342,5 +1326,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]

--- a/icicle-cpu/src/cpu.rs
+++ b/icicle-cpu/src/cpu.rs
@@ -668,7 +668,7 @@ impl<'a> PcodeExecutor for UncheckedExecutor<'a> {
         match id {
             pcode::RAM_SPACE => {
                 if let Err(err) = self.cpu.mem.write(addr, value, perm::WRITE) {
-                    self.exception(ExceptionCode::from_load_error(err), addr);
+                    self.exception(ExceptionCode::from_store_error(err), addr);
                     return None;
                 }
             }

--- a/icicle-cpu/src/debug_info.rs
+++ b/icicle-cpu/src/debug_info.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, rc::Rc};
 
-use object::{Object, ObjectSection};
+use object::{Object, ObjectKind, ObjectSection, ObjectSymbol};
 
 pub type Addr2LineCtx = addr2line::Context<gimli::EndianRcSlice<gimli::RunTimeEndian>>;
 
@@ -42,38 +42,45 @@ impl DebugInfo {
     // @todo: consider doing this on-demand.
     // @todo: avoid needing to mantain a separate copy of the binary in memory.
     pub fn add_file(&mut self, data: &[u8], load_address: u64) -> Result<(), String> {
-        use object::{Object, ObjectKind, ObjectSymbol};
-
-        let file =
+        let object =
             object::read::File::parse(data).map_err(|e| format!("Error parsing elf: {}", e))?;
 
-        let relocation_offset = if file.kind() == ObjectKind::Dynamic { load_address } else { 0 };
+        let relocation_offset = if object.kind() == ObjectKind::Dynamic { load_address } else { 0 };
 
-        let endian = if file.is_little_endian() {
+        let endian = if object.is_little_endian() {
             gimli::RunTimeEndian::Little
         }
         else {
             gimli::RunTimeEndian::Big
         };
 
-        let dwarf = dwarf_ctx(&file, endian)
+        let dwarf = dwarf_ctx(&object, endian)
             .map_err(|err| format!("error loading debug info from object file: {err}"))?;
         match addr2line::Context::from_dwarf(dwarf) {
             Ok(ctx) => {
                 self.ctx.insert(relocation_offset, std::rc::Rc::new(ctx));
             }
-            Err(e) => tracing::warn!("failed to get DWARF debug context: {}", e),
+            Err(e) => tracing::warn!("failed to get DWARF debug context: {e}"),
         }
 
-        for sym in file.symbols().chain(file.dynamic_symbols()) {
+        tracing::info!("Loaded object file with architecture {:?}", object.architecture());
+        let is_arm = matches!(object.architecture(), object::Architecture::Arm);
+
+        for sym in object.symbols().chain(object.dynamic_symbols()) {
             let name = match sym.name() {
                 Ok(name) => name,
                 Err(_) => continue,
             };
-            let addr = sym.address() + relocation_offset;
+            let mut addr = sym.address() + relocation_offset;
             if addr < load_address {
                 continue;
             }
+            if is_arm && matches!(sym.kind(), object::SymbolKind::Text | object::SymbolKind::Label)
+            {
+                // Clear thumb bit
+                addr &= !1;
+            }
+
             std::rc::Rc::make_mut(&mut self.symbols).insert(
                 name.to_string(),
                 addr,
@@ -180,10 +187,9 @@ impl DebugInfo {
 
     /// Return an iterator over all symbols found in the section headers.
     pub fn symbols_iter(&self) -> impl Iterator<Item = (u64, u64, &str, SymbolKind)> {
-        self.symbols
-            .addr_to_sym
-            .iter()
-            .map(|(start, (name, len, kind))| (*start, *len, name.as_str(), *kind))
+        self.symbols.addr_to_sym.iter().flat_map(|(start, entries)| {
+            entries.iter().map(|(name, len, kind)| (*start, *len, name.as_str(), *kind))
+        })
     }
 
     /// Strip the original prefix (from the debug info) from `path` and return the remapped host
@@ -213,7 +219,7 @@ fn dwarf_ctx(
     let load_section = |id: gimli::SectionId| -> anyhow::Result<Rc<[u8]>> {
         Ok(match object.section_by_name(id.name()) {
             Some(section) => section.uncompressed_data()?.into(),
-            None => Rc::default(),
+            None => Rc::new([]),
         })
     };
     let dwarf_sections = gimli::DwarfSections::load(load_section)?;
@@ -265,7 +271,7 @@ where
 #[derive(Debug, Clone, Default)]
 pub struct SymbolTable {
     pub sym_to_addr: BTreeMap<String, (u64, u64, SymbolKind)>,
-    pub addr_to_sym: BTreeMap<u64, (String, u64, SymbolKind)>,
+    pub addr_to_sym: BTreeMap<u64, Vec<(String, u64, SymbolKind)>>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -279,7 +285,6 @@ pub enum SymbolKind {
 }
 
 fn get_symbol_kind(sym: &object::Symbol) -> SymbolKind {
-    use object::ObjectSymbol;
     match sym.kind() {
         object::SymbolKind::Text => SymbolKind::Function,
         object::SymbolKind::Label => SymbolKind::Label,
@@ -295,18 +300,38 @@ impl SymbolTable {
     /// Inserts a value into the symbol table
     pub fn insert(&mut self, name: String, addr: u64, len: u64, kind: SymbolKind) {
         self.sym_to_addr.insert(name.clone(), (addr, len, kind));
-        self.addr_to_sym.insert(addr, (name, len, kind));
+        self.addr_to_sym.entry(addr).or_default().push((name, len, kind));
     }
 
     /// Attempts to resolve a address to a symbol returning the name of the symbol and its starting
     /// address
     pub fn resolve_addr(&self, addr: u64) -> Option<(&str, u64, SymbolKind)> {
         // @fixme: optimize this search to avoid needing to iterate though the entire symbol array
-        for (start, (name, len, kind)) in self.addr_to_sym.range(..=addr).rev() {
-            if addr < start + len {
+        for (start, entries) in self.addr_to_sym.range(..=addr).rev() {
+            let mut filtered_iter = entries.iter().filter(|(_, len, _)| addr < start + len);
+
+            // First try to find a function-like symbol that matches the current address.
+            if let Some((name, _, kind)) =
+                filtered_iter.clone().find(|(_, _, kind)| matches!(kind, SymbolKind::Function))
+            {
+                return Some((name, *start, *kind));
+            }
+
+            // Otherwise just get an arbitary entry.
+            if let Some((name, _, kind)) = filtered_iter.next() {
                 return Some((name, *start, *kind));
             }
         }
+
+        // If we still failed to find a maching symbol, just get the symbol that is closest.
+        for (start, entries) in self.addr_to_sym.range(..=addr).rev() {
+            if let Some((name, _, kind)) =
+                entries.iter().find(|(_, _, kind)| matches!(kind, SymbolKind::Function))
+            {
+                return Some((name, *start, *kind));
+            }
+        }
+
         None
     }
 
@@ -324,6 +349,17 @@ pub struct SourceLocation {
     pub line: Option<u32>,
     pub column: Option<u32>,
     pub library_name_and_offset: Option<(Vec<u8>, u64)>,
+}
+
+impl SourceLocation {
+    pub fn label(&self) -> Option<String> {
+        self.function.as_ref().map(|(name, _)| name.clone()).or_else(|| {
+            self.symbol_with_offset.as_ref().map(|(name, offset)| match offset {
+                0 => name.clone(),
+                _ => format!("{name}+{offset:#x}"),
+            })
+        })
+    }
 }
 
 impl SourceLocation {
@@ -357,7 +393,7 @@ impl std::fmt::Display for SourceLocation {
                 write!(f, ":{}", line)?;
             }
             if let Some(column) = self.column {
-                write!(f, ".{}", column)?;
+                write!(f, ":{}", column)?;
             }
         }
 
@@ -377,7 +413,7 @@ impl<'a> std::fmt::Display for SourceLocationDisplayFile<'a> {
                 write!(f, ":{}", line)?;
             }
             if let Some(column) = self.source.column {
-                write!(f, ".{}", column)?;
+                write!(f, ":{}", column)?;
             }
         }
 

--- a/icicle-jit/Cargo.toml
+++ b/icicle-jit/Cargo.toml
@@ -12,12 +12,12 @@ pcode = { workspace = true }
 target-lexicon = { workspace = true }
 tracing = { workspace = true }
 memoffset = "0.9.1"
-cranelift = "0.112.0"
-cranelift-native = "0.112.0"
-cranelift-module = "0.112.0"
-cranelift-jit = "0.112.0"
-cranelift-codegen = { version = "0.112.0", default-features = false, features = ["std"] }
-wasmtime-jit-debug = { version = "25.0.0", features = ["perf_jitdump"] }
+cranelift = "0.113.0"
+cranelift-native = "0.113.0"
+cranelift-module = "0.113.0"
+cranelift-jit = "0.113.0"
+cranelift-codegen = { version = "0.113.0", default-features = false, features = ["std"] }
+wasmtime-jit-debug = { version = "26.0.0", features = ["perf_jitdump"] }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/icicle-jit/Cargo.toml
+++ b/icicle-jit/Cargo.toml
@@ -12,12 +12,12 @@ pcode = { workspace = true }
 target-lexicon = { workspace = true }
 tracing = { workspace = true }
 memoffset = "0.9.1"
-cranelift = "0.110.1"
-cranelift-native = "0.110.1"
-cranelift-module = "0.110.1"
-cranelift-jit = "0.110.1"
-cranelift-codegen = { version = "0.110.1", default-features = false, features = ["std"] }
-wasmtime-jit-debug = { version = "23.0.1", features = ["perf_jitdump"] }
+cranelift = "0.112.0"
+cranelift-native = "0.112.0"
+cranelift-module = "0.112.0"
+cranelift-jit = "0.112.0"
+cranelift-codegen = { version = "0.112.0", default-features = false, features = ["std"] }
+wasmtime-jit-debug = { version = "25.0.0", features = ["perf_jitdump"] }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/icicle-jit/src/translate/mem.rs
+++ b/icicle-jit/src/translate/mem.rs
@@ -213,6 +213,14 @@ fn load_host(trans: &mut Translator, addr: Value, size: u8) -> Value {
 
 /// Generate code for loading a value from RAM.
 pub(super) fn load_ram(trans: &mut Translator, guest_addr: pcode::Value, output: pcode::VarNode) {
+    // Flush all registers _before_ performing memory accesses if requested, to avoid state in the
+    // fallback case diverging from the hot path. Even though the memory API technically does not
+    // support viewing/modifying registers in practice this is possible (e.g., by taking a raw
+    // pointer to the CPU struct), and we may want to fully support it in the future.
+    if trans.ctx.flush_before_mem {
+        trans.flush_state(true);
+    }
+
     let size = output.size;
     if !is_jit_supported_size(size) || trans.ctx.disable_jit_mem {
         trans.interpret(pcode::Instruction::from((
@@ -220,6 +228,9 @@ pub(super) fn load_ram(trans: &mut Translator, guest_addr: pcode::Value, output:
             pcode::Op::Load(pcode::RAM_SPACE),
             pcode::Inputs::one(guest_addr),
         )));
+        if trans.ctx.reload_after_mem {
+            trans.varnode_fence();
+        }
         // Check for memory exceptions.
         trans.maybe_exit_jit(None);
         return;
@@ -259,6 +270,9 @@ pub(super) fn load_ram(trans: &mut Translator, guest_addr: pcode::Value, output:
     // success:
     trans.builder.switch_to_block(success_block);
     trans.builder.seal_block(success_block);
+    if trans.ctx.reload_after_mem {
+        trans.varnode_fence();
+    }
 
     let value = trans.builder.block_params(success_block)[0];
     trans.write(output, value);
@@ -304,12 +318,20 @@ pub(super) fn store_host(trans: &mut Translator, addr: Value, mut value: Value, 
 
 /// Generate code for storing a value to RAM.
 pub(super) fn store_ram(trans: &mut Translator, guest_addr: pcode::Value, value: pcode::Value) {
+    // See note in `load_ram`
+    if trans.ctx.flush_before_mem {
+        trans.flush_state(true);
+    }
+
     let size = value.size();
     if !is_jit_supported_size(size) || trans.ctx.disable_jit_mem {
         trans.interpret(pcode::Instruction::from((
             pcode::Op::Store(pcode::RAM_SPACE),
             pcode::Inputs::new(guest_addr, value),
         )));
+        if trans.ctx.reload_after_mem {
+            trans.varnode_fence();
+        }
         // Check for memory exceptions.
         trans.maybe_exit_jit(None);
         return;
@@ -349,6 +371,9 @@ pub(super) fn store_ram(trans: &mut Translator, guest_addr: pcode::Value, value:
     // success:
     trans.builder.switch_to_block(success_block);
     trans.builder.seal_block(success_block);
+    if trans.ctx.reload_after_mem {
+        trans.varnode_fence();
+    }
 }
 
 /// Handle complex stores using a function provided by the runtime.

--- a/icicle-jit/src/translate/mod.rs
+++ b/icicle-jit/src/translate/mod.rs
@@ -330,7 +330,7 @@ impl TranslatorCtx {
             reg_pc: arch.reg_pc,
             disable_jit_mem: false,
             disable_jit_reg: false,
-            always_flush_vars: true,
+            always_flush_vars: false,
             flush_before_mem: true,
             reload_after_mem: false,
             enable_shadow_stack: true,

--- a/icicle-jit/src/translate/mod.rs
+++ b/icicle-jit/src/translate/mod.rs
@@ -61,6 +61,8 @@ impl MemHandler<FuncRef> {
     }
 }
 
+pub const TRAP_UNREACHABLE: TrapCode = TrapCode::unwrap_user(1);
+
 /// Checks whether the size of a value is a size that the JIT can handle natively.
 fn is_jit_supported_size(size_in_bytes: u8) -> bool {
     [1, 2, 4, 8, 16].contains(&size_in_bytes)
@@ -452,7 +454,7 @@ fn define_jit_entry(builder: &mut FunctionBuilder, ctx: &mut TranslatorCtx) -> (
             builder.set_cold_block(trap_block);
             builder.switch_to_block(trap_block);
             builder.seal_block(trap_block);
-            builder.ins().trap(TrapCode::UnreachableCodeReached);
+            builder.ins().trap(TRAP_UNREACHABLE);
         }
     }
 

--- a/icicle-jit/src/translate/ops.rs
+++ b/icicle-jit/src/translate/ops.rs
@@ -65,7 +65,9 @@ impl<'a, 'b> Ctx<'a, 'b> {
 
     pub fn call_hook(&mut self, id: pcode::HookId) {
         // Currently we assume all hooks need state to be flushed to memory.
-        self.trans.flush_state();
+        //
+        // @fixme: allow some hooks to only flush some variables.
+        self.trans.varnode_fence();
 
         let current_pc = self.trans.builder.ins().iconst(types::I64, self.trans.last_addr as i64);
 

--- a/icicle-mem/src/mmu.rs
+++ b/icicle-mem/src/mmu.rs
@@ -285,12 +285,15 @@ impl Mmu {
         self.physical.allocated_pages()
     }
 
-    #[allow(unused)]
+    /// Gets the current physical memory page limit.
     pub fn capacity(&self) -> usize {
         self.physical.capacity()
     }
 
-    #[allow(unused)]
+    /// Sets the maximum number of physical pages the mmu is allowed to allocate.
+    ///
+    /// Note: If `new_capacity` is smaller than the current number of allocated pages, then the
+    /// capacity is set to the number of allocated pages.
     pub fn set_capacity(&mut self, new_capacity: usize) -> bool {
         self.physical.set_capacity(new_capacity)
     }

--- a/icicle-mem/src/physical.rs
+++ b/icicle-mem/src/physical.rs
@@ -236,6 +236,7 @@ impl Page {
         self.executed = false;
     }
 
+    #[inline(always)]
     pub fn data(&self) -> &PageData {
         // Safety: Either we have a unique copy of `self.data` or there are no active mutable
         // references.
@@ -244,6 +245,7 @@ impl Page {
         unsafe { self.data.get().as_ref().unwrap() }
     }
 
+    #[inline(always)]
     pub fn data_mut(&mut self) -> &mut PageData {
         Rc::make_mut(self.data.get_mut())
     }
@@ -254,6 +256,7 @@ impl Page {
     ///
     /// The returned pointer is only valid while `data` is valid and unique (e.g., the pointer must
     /// not be used after a call to [Page::clone] or [Drop::drop]).
+    #[inline(always)]
     pub unsafe fn write_ptr(&mut self) -> PageRef {
         PageRef::new(self.data_mut().into())
     }
@@ -264,6 +267,7 @@ impl Page {
     ///
     /// The returned pointer is only valid while `data` is valid (e.g., the pointer must not be used
     /// after a call to [Drop::drop]).
+    #[inline(always)]
     pub unsafe fn read_ptr(&mut self) -> PageRef {
         PageRef::new(NonNull::new(Rc::as_ptr(self.data.get_mut()) as *mut _).unwrap())
     }

--- a/icicle-mem/src/physical.rs
+++ b/icicle-mem/src/physical.rs
@@ -108,7 +108,7 @@ impl PhysicalMemory {
             return false;
         }
         self.capacity = new_capacity;
-        return true
+        true
     }
 
     #[allow(unused)] // @fixme: This should be called when we unmap pages

--- a/sleigh/sleigh-compile/src/constructor/semantics.rs
+++ b/sleigh/sleigh-compile/src/constructor/semantics.rs
@@ -728,6 +728,7 @@ impl<'a, 'b> Builder<'a, 'b> {
                         ExprValue::Local(mut value) => match value.local {
                             Local::Subtable(idx) => {
                                 value.local = Local::SubtableRef(idx);
+                                value.size = Some(self.pointer_size);
                                 value
                             }
                             _ => value,

--- a/sleigh/sleigh-runtime/src/lib.rs
+++ b/sleigh/sleigh-runtime/src/lib.rs
@@ -11,7 +11,7 @@ pub mod semantics;
 use std::{collections::HashMap, fmt::Display};
 
 pub use crate::{
-    decoder::{ContextModValue, Decoder, DisasmConstantValue, Instruction},
+    decoder::{ContextModValue, Decoder, DisasmConstantValue, Instruction, SubtableCtx},
     expr::PatternExprOp,
     lifter::{Error as LifterError, Lifter},
 };

--- a/sleigh/sleigh-runtime/src/lifter.rs
+++ b/sleigh/sleigh-runtime/src/lifter.rs
@@ -528,9 +528,9 @@ impl<'a, 'b> LifterCtx<'a, 'b> {
             Local::SubtableRef(idx) => {
                 match self.subtable_export(idx).ok_or(Error::InvalidVarNode)? {
                     Operand::Value(value) => value.slice(value_offset, value_size).into(),
-                    Operand::Pointer(var, base, size) => {
+                    Operand::Pointer(var, base, _) => {
                         let offset = base.try_into().map_err(|_| Error::InvalidVarNode)?;
-                        var.slice(offset, size).into()
+                        var.slice(offset, value_size).into()
                     }
                 }
             }
@@ -811,6 +811,7 @@ impl<'a, 'b> LifterCtx<'a, 'b> {
             self.get_runtime_var(tmp)?
         };
         let base = self.get_runtime_value(base)?;
+        let offset = pcode::Value::Const(offset, base.size());
         self.push((addr, pcode::Op::IntAdd, pcode::Inputs::new(base, offset)));
         Ok(addr.into())
     }


### PR DESCRIPTION
- SLEIGH compiler fixes for certain (rarely used) expressions.
- Optimize register management in the JIT by avoiding excess register flushes. This results in ~20% performance improvement for register heavy code.
- Improve symbol debugging when partial debug info is present (for MultiFuzz).
- Add experimental support for GDB watchpoints (Note: this HIGHLY experimental, and only intended to be used for MultiFuzz).
- Update cranelift dependencies.