### PR TITLE
Add support for execute-only memory

### DIFF
--- a/icicle-mem/src/physical.rs
+++ b/icicle-mem/src/physical.rs
@@ -57,10 +57,13 @@ pub struct PhysicalMemory {
 }
 
 impl PhysicalMemory {
+    const READ_ONLY_ZERO_PERM: u8 = perm::MAP | perm::READ | perm::INIT;
+
+    const READ_WRITE_ZERO_PERM: u8 = perm::MAP | perm::READ | perm::WRITE | perm::INIT;
+
     pub fn new(capacity: usize) -> Self {
-        let zero_page_read_only = Page::zero_page(perm::READ | perm::INIT | perm::MAP, false);
-        let zero_page_read_write =
-            Page::zero_page(perm::READ | perm::WRITE | perm::INIT | perm::MAP, true);
+        let zero_page_read_only = Page::zero_page(Self::READ_ONLY_ZERO_PERM, false);
+        let zero_page_read_write = Page::zero_page(Self::READ_WRITE_ZERO_PERM, true);
         Self { capacity, allocated: vec![zero_page_read_only, zero_page_read_write], free: vec![] }
     }
 
@@ -117,13 +120,12 @@ impl PhysicalMemory {
     }
 
     #[inline]
-    pub fn read_only_zero_page(&self) -> Index {
-        Index(0)
-    }
-
-    #[inline]
-    pub fn zero_page(&self) -> Index {
-        Index(1)
+    pub fn get_zero_page(&self, perm: u8) -> Option<Index> {
+        match perm {
+            PhysicalMemory::READ_ONLY_ZERO_PERM => Some(Index(0)),
+            PhysicalMemory::READ_WRITE_ZERO_PERM => Some(Index(1)),
+            _ => None,
+        }
     }
 
     #[inline]


### PR DESCRIPTION
- The `page.executed` assignment is moved to after the check, since we might exit early here and then incorrectly mark non-executable code as executed.
- Do not check for `perm::READ` in `ensure_executable` (this is what adds support)
- Do not modify the permissions when detecting self-modifying code, only add `perm::IN_CODE_CACHE` (since this is already checked in `write_physical -> check_self_modifying_write`)

Some open issues to potentially handle later:
- Introduce a new `MemError::ExecUninitialized` and propagate this up from `ensure_exec` (requires more significant changes). The reason for this is that executing uninitialized code will return a confusing error to the user
- There is a bug where stepping over a single-byte `nop` instruction triggers the `ExecUninitialized` state (still needs more investigation)
- There might be a bug that allows reading from a zero execute-only page regardless of the permissions (also needs more investigation)