### PR TITLE
Make sure `InstructionLimit` is prioritized over a `DecodeError` at the end of the block

### DIFF
--- a/icicle-cpu/src/cpu.rs
+++ b/icicle-cpu/src/cpu.rs
@@ -68,11 +68,17 @@ impl std::fmt::Debug for ShadowStackEntry {
     }
 }
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
 pub struct Exception {
     pub code: u32,
     pub value: u64,
+}
+
+impl From<(ExceptionCode, u64)> for Exception {
+    fn from(value: (ExceptionCode, u64)) -> Self {
+        Self::new(value.0, value.1)
+    }
 }
 
 impl Exception {

--- a/icicle-cpu/src/lib.rs
+++ b/icicle-cpu/src/lib.rs
@@ -354,6 +354,7 @@ impl From<DecodeError> for ExceptionCode {
 pub enum InternalError {
     CorruptedBlockMap,
     UnsupportedIsaMode,
+    SwitchToInterpreter,
 }
 
 pub fn read_value_zxt(cpu: &mut Cpu, value: pcode::Value) -> u64 {

--- a/icicle-jit/src/runtime.rs
+++ b/icicle-jit/src/runtime.rs
@@ -1,4 +1,4 @@
-use icicle_cpu::{mem::perm, Cpu, ExceptionCode};
+use icicle_cpu::{mem::perm, Cpu, ExceptionCode, InternalError};
 
 pub unsafe extern "C" fn jit_compilation_error(cpu: *mut Cpu, addr: u64) -> u64 {
     (*cpu).exception.code = ExceptionCode::JitError as u32;
@@ -17,10 +17,8 @@ pub unsafe extern "C" fn address_not_translated(cpu: *mut Cpu, addr: u64) -> u64
     addr
 }
 
-pub unsafe extern "C" fn block_contains_breakpoint(cpu: *mut Cpu, addr: u64) -> u64 {
-    // Exit with the `InstructionLimit` exit code this results in us exiting to the interpreter
-    // which will single step the CPU until the correct instruction.
-    (*cpu).exception.code = ExceptionCode::InstructionLimit as u32;
+pub unsafe extern "C" fn switch_to_interpreter(cpu: *mut Cpu, addr: u64) -> u64 {
+    (*cpu).exception = (ExceptionCode::InternalError, InternalError::SwitchToInterpreter as u64).into();
     addr
 }
 

--- a/icicle-jit/src/translate/mod.rs
+++ b/icicle-jit/src/translate/mod.rs
@@ -1045,14 +1045,14 @@ impl<'a> Translator<'a> {
         // @fixme: make `fuel` a variable.
         let remaining_fuel = self.vm_ptr.load_fuel(&mut self.builder);
         let required_fuel = num_instructions as i64;
-        let insufficient_fuel =
-            self.builder.ins().icmp_imm(IntCC::SignedLessThan, remaining_fuel, required_fuel);
+        let switch_to_interpreter =
+            self.builder.ins().icmp_imm(IntCC::SignedLessThanOrEqual, remaining_fuel, required_fuel);
 
         let ok_block = self.builder.create_block();
         let err_block = self.builder.create_block();
         self.builder.set_cold_block(err_block);
 
-        self.builder.ins().brif(insufficient_fuel, err_block, &[], ok_block, &[]);
+        self.builder.ins().brif(switch_to_interpreter, err_block, &[], ok_block, &[]);
 
         // err:
         {

--- a/icicle-jit/src/translate/mod.rs
+++ b/icicle-jit/src/translate/mod.rs
@@ -16,7 +16,7 @@ use cranelift_module::{FuncId, Module};
 use icicle_cpu::{
     cpu::{Fuel, JitContext},
     lifter::{Block as IcicleBlock, BlockExit, Target},
-    Arch, Cpu, Exception, ExceptionCode, Regs,
+    Arch, Cpu, Exception, ExceptionCode, Regs, InternalError,
 };
 use memoffset::offset_of;
 
@@ -1058,7 +1058,7 @@ impl<'a> Translator<'a> {
         {
             self.builder.switch_to_block(err_block);
             self.builder.seal_block(err_block);
-            self.exit_with_exception(ExceptionCode::InstructionLimit, 0);
+            self.exit_with_exception(ExceptionCode::InternalError, InternalError::SwitchToInterpreter as u64);
         }
 
         // ok:

--- a/icicle-vm/src/lib.rs
+++ b/icicle-vm/src/lib.rs
@@ -449,8 +449,15 @@ impl Vm {
                     // the middle of a block).
                     self.cpu.write_pc(addr);
 
-                    // Raise the exception
-                    self.cpu.exception = Exception::new(ExceptionCode::from(e), addr);
+                    // Since the invalid instruction does not have a marker, we need to check if we
+                    // ran out of fuel and raise the appropriate exception first. The next step will
+                    // raise the actual exception related to the DecodeError.
+                    let code = if self.cpu.fuel.remaining == 0 {
+                        ExceptionCode::InstructionLimit
+                    } else {
+                        ExceptionCode::from(e)
+                    };
+                    self.cpu.exception = Exception::new(code, addr);
                     break;
                 }
             }


### PR DESCRIPTION
This fixes a bug where the following sequence triggers a `DecodeError` instead of the expected `InstructionLimit`:

```python
vm.write(rip, b"\x90\x90\x06") # nop; nop; <invalid>
vm.step(2)
```

The solution has two components:
1. When interpreting, check the remaining fuel before raising the exception
   - The downside here is that we might interpret `max_instructions_per_block` that could _technically_ be JIT-ed. I don't think this is a terribly common case though, so it shouldn't matter in real-world scenarios.
3. If there is _just enough_ fuel to JIT a block, interpret instead

I also introduced a dedicated `InternalError::SwitchToInterpreter`, because reusing the `InstructionLimit` exception for this was extremely confusing when reading the code.