### PR TITLE
Add functions to icicle_vm::builder allowing custom processor directories

### DIFF
--- a/icicle-vm/src/lib.rs
+++ b/icicle-vm/src/lib.rs
@@ -14,7 +14,7 @@ pub use icicle_cpu::VmExit;
 pub use icicle_linux as linux;
 
 pub use crate::{
-    builder::{build, sleigh_init, x86, BuildError},
+    builder::{build, build_with_path, sleigh_init, x86, BuildError},
     injector::{CodeInjector, InjectorRef},
 };
 pub use icicle_cpu::BlockTable;


### PR DESCRIPTION
I want to be able to not have "Ghidra/Processors" in the path for my processor files, and avoid setting an environment variable. This should allow that while maintaining compatibility 