### PR TITLE
Improved compatibility with newer SLEIGH specifications and bug fixes

### DIFF
--- a/icicle-cpu/src/cpu.rs
+++ b/icicle-cpu/src/cpu.rs
@@ -394,7 +394,7 @@ impl Cpu {
     pub fn var_for_offset(&self, offset: u32, size: u8) -> Option<pcode::VarNode> {
         let (reg, reg_offset) = self.arch.sleigh.map_sleigh_reg(offset, size)?;
         // @todo: check behaviour of big-endian dynamic accesses.
-        reg.get_var(reg_offset, size)
+        reg.slice_var(reg_offset, size)
     }
 
     /// Reads the register represented by `var`. For special registers, this may perform additional

--- a/icicle-cpu/src/exec/const_eval.rs
+++ b/icicle-cpu/src/exec/const_eval.rs
@@ -15,12 +15,17 @@ pub struct ConstEval {
     pub inputs: HashMap<i16, usize>,
 
     /// Keeps track which values are already stored in VarNodes.
-    pub results: HashMap<Value, pcode::VarNode>,
+    results: HashMap<Value, pcode::VarNode>,
 }
 
 impl ConstEval {
     pub fn new() -> Self {
         Self { inputs: HashMap::new(), values: vec![], results: HashMap::new() }
+    }
+
+    pub fn purge_temporaries(&mut self, is_temporary: impl Fn(pcode::VarId) -> bool) {
+        self.results.clear();
+        self.inputs.retain(|id, _| is_temporary(*id));
     }
 
     pub fn eval(&mut self, stmt: pcode::Instruction) -> OutputExprId {
@@ -40,9 +45,9 @@ impl ConstEval {
         eval(stmt.op, &a, &b, out);
 
         if DEBUG && !out.is_empty() {
-            eprintln!("a = {} {:?}", a, a);
+            eprintln!("a = {a} {a:?}");
             if !b.is_empty() {
-                eprintln!("b = {} {:?}", b, b);
+                eprintln!("b = {b} {b:?}");
             }
             eprintln!("x = {} {:?}", out.display(), out.display());
         }
@@ -943,7 +948,7 @@ fn display_bits(bits: &[Bit], f: &mut std::fmt::Formatter) -> std::fmt::Result {
             Bit::Zero => '0',
             Bit::One => '1',
         };
-        write!(f, "{}", x)?;
+        write!(f, "{x}")?;
     }
 
     Ok(())
@@ -955,7 +960,7 @@ fn debug_bits(bits: &[Bit], f: &mut std::fmt::Formatter) -> std::fmt::Result {
     }
 
     if let Some(x) = bits.get_const() {
-        write!(f, " ({:#0x})", x)?;
+        write!(f, " ({x:#0x})")?;
     }
     else {
         write!(f, " (")?;

--- a/icicle-cpu/src/exec/helpers.rs
+++ b/icicle-cpu/src/exec/helpers.rs
@@ -19,7 +19,13 @@ pub const HELPERS: &[(&str, PcodeOpHelper)] = &[
     ("UnsignedDoesSaturate", unsigned_does_saturate),
     ("SignedSaturate", signed_saturate),
     ("SignedDoesSaturate", signed_does_saturate),
+    ("setISAMode", set_isa_mode),
 ];
+
+fn set_isa_mode(_cpu: &mut Cpu, _: VarNode, _: [Value; 2]) {
+    // Icicle checks for ISA mode switches on every block so does not need this function to be
+    // called explicitly.
+}
 
 fn enable_interrupts(_cpu: &mut Cpu, _: VarNode, _: [Value; 2]) {
     // @todo
@@ -127,34 +133,85 @@ fn bcd_add_digit(a: u8, b: u8, carry: u8) -> (u8, u8) {
     }
 }
 
+fn unsigned_saturate_impl(value: i64, bits: u32) -> (i64, bool) {
+    let max: i64 = (1 << bits) - 1;
+    if value < 0 {
+        (0, true)
+    }
+    else if value > max {
+        (max, true)
+    }
+    else {
+        (value, false)
+    }
+}
+
 fn unsigned_saturate(cpu: &mut Cpu, dst: pcode::VarNode, args: [Value; 2]) {
     let bits: u32 = cpu.read_dynamic(args[1]).zxt();
-    let max = (1 << bits) - 1;
-    let value: u64 = cpu.read_dynamic(args[0]).zxt();
-    cpu.write_trunc(dst, u64::min(value, max));
+    // Some uses of `UnsignedSaturate` in SLEIGH do nothing because the bits have already been
+    // truncated. Here we try to detect bugs in the spec by returning an error if the result would
+    // never change.
+    if bits >= (args[0].size() as u32 * 8) || bits >= 64 {
+        cpu.exception.code = ExceptionCode::InvalidOpSize as u32;
+        cpu.exception.value = args[0].size() as u64;
+        return;
+    }
+
+    let value: i64 = cpu.read_dynamic(args[0]).sxt();
+    let (value, _) = unsigned_saturate_impl(value, bits);
+    cpu.write_trunc(dst, value as u64);
 }
 
 fn unsigned_does_saturate(cpu: &mut Cpu, dst: pcode::VarNode, args: [Value; 2]) {
     let bits: u32 = cpu.read_dynamic(args[1]).zxt();
-    let max = (1 << bits) - 1;
-    let value: u64 = cpu.read_dynamic(args[0]).zxt();
-    cpu.write_var::<u8>(dst, (value > max) as u8);
+    if bits >= (args[0].size() as u32 * 8) || bits >= 64 {
+        cpu.exception.code = ExceptionCode::InvalidOpSize as u32;
+        cpu.exception.value = args[0].size() as u64;
+        return;
+    }
+
+    let value: i64 = cpu.read_dynamic(args[0]).sxt();
+    let (_, saturates) = unsigned_saturate_impl(value, bits);
+    cpu.write_var::<u8>(dst, saturates as u8);
+}
+
+fn signed_saturate_impl(value: i64, bits: u32) -> (i64, bool) {
+    let max = (1 << (bits - 1)) - 1;
+    let min = -(1 << (bits - 1));
+    if value < min {
+        (min, true)
+    }
+    else if value > max {
+        (max, true)
+    }
+    else {
+        (value, false)
+    }
 }
 
 fn signed_saturate(cpu: &mut Cpu, dst: pcode::VarNode, args: [Value; 2]) {
     let bits: u32 = cpu.read_dynamic(args[1]).zxt();
-    let max = (1 << (bits - 1)) - 1;
-    let min = -(1 << (bits - 1));
+    if bits >= (args[0].size() as u32 * 8) || bits >= 64 {
+        cpu.exception.code = ExceptionCode::InvalidOpSize as u32;
+        cpu.exception.value = args[0].size() as u64;
+        return;
+    }
+
     let value: i64 = cpu.read_dynamic(args[0]).sxt();
-    cpu.write_trunc(dst, (value).min(max).max(min) as u64);
+    let (value, _) = signed_saturate_impl(value, bits);
+    cpu.write_trunc(dst, value as u64);
 }
 
 fn signed_does_saturate(cpu: &mut Cpu, dst: pcode::VarNode, args: [Value; 2]) {
     let bits: u32 = cpu.read_dynamic(args[1]).zxt();
-    let max = (1 << (bits - 1)) - 1;
-    let min = -(1 << (bits - 1));
+    if bits >= (args[0].size() as u32 * 8) || bits >= 64 {
+        cpu.exception.code = ExceptionCode::InvalidOpSize as u32;
+        cpu.exception.value = args[0].size() as u64;
+        return;
+    }
     let value: i64 = cpu.read_dynamic(args[0]).sxt();
-    cpu.write_var::<u8>(dst, (value < min || value > max) as u8);
+    let (_, saturates) = unsigned_saturate_impl(value, bits);
+    cpu.write_var::<u8>(dst, saturates as u8);
 }
 
 #[allow(unused)]
@@ -207,6 +264,7 @@ pub mod x86 {
         ("movmskpd", movmskpd),
         ("pinsrw", pinsrw), // Note: implemented in SLEIGH in Ghidra 10.3.
         ("pshuflw", pshuflw),
+        ("pshufhw", pshufhw),
         ("shufpd", shufpd), // Note: implemented in SLEIGH in Ghidra 10.3.
         ("pmaddwd", pmaddwd),
         ("in", in_io),
@@ -266,9 +324,21 @@ pub mod x86 {
 
         let eax: u32 =
             (extended_family << 20) | (extended_model << 16) | (family << 8) | (model << 4);
+
+        use cpuid::FeatureInformationEcx as Feature;
+
+        let ecx: u32 = (Feature::sse3
+            | Feature::tm2
+            | Feature::pdcm
+            | Feature::popcnt
+            | Feature::tsc_deadline
+            | Feature::aesni
+            | Feature::xsave)
+            .bits();
+
         cpu.write_var(dst.slice(0, 4), eax);
         cpu.write_var(dst.slice(4, 4), 0_u32);
-        cpu.write_var(dst.slice(8, 4), 0_u32);
+        cpu.write_var(dst.slice(8, 4), ecx);
         cpu.write_var(dst.slice(12, 4), 0_u32);
     }
 
@@ -343,7 +413,7 @@ pub mod x86 {
         }
     }
 
-    // Extract Packed Double-Precision Floating-Point Sign Mask
+    /// Extract Packed Double-Precision Floating-Point Sign Mask
     fn movmskpd(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
         let src = cpu.read::<u128>(args[1]);
         let result = ((src >> 63) & 0b01) as u32 | ((src >> 126) & 0b10) as u32;
@@ -352,7 +422,7 @@ pub mod x86 {
         cpu.write_var(VarNode::new(dst.id, 8), result as u64);
     }
 
-    // Insert word
+    /// Insert word
     #[allow(unused)]
     fn pinsrw(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
         // The byte offset to insert the word at
@@ -362,11 +432,12 @@ pub mod x86 {
         cpu.write_var(dst.slice(offset as u8, 2), src as u16);
     }
 
-    // Shuffle packed low words
+    /// Shuffle packed low words
     fn pshuflw(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
         let src = cpu.read::<u64>(args[1].slice(0, 8));
         let count = cpu.args[0] as u64;
 
+        // Shuffle low bits
         for offset in 0..4 {
             let shift = (count >> (offset * 2) & 0b11) * 16;
             let value = (src >> shift) & 0xffff;
@@ -378,7 +449,24 @@ pub mod x86 {
         cpu.write_var(dst.slice(8, 8), src_hi)
     }
 
-    // Packed interleave shuffle
+    /// Shuffle packed high words
+    fn pshufhw(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
+        let src = cpu.read::<u64>(args[1].slice(8, 8));
+        let count = cpu.args[0] as u64;
+
+        // Copy low bits
+        let src_low = cpu.read::<u64>(args[1].slice(0, 8));
+        cpu.write_var(dst.slice(0, 8), src_low);
+
+        // Shuffle high bits
+        for offset in 0..4 {
+            let shift = (count >> (offset * 2) & 0b11) * 16;
+            let value = (src >> shift) & 0xffff;
+            cpu.write_var(dst.slice(8 + offset * 2, 2), value as u16);
+        }
+    }
+
+    /// Packed interleave shuffle
     #[allow(unused)]
     fn shufpd(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
         let index = cpu.args[0] as u64;
@@ -458,6 +546,43 @@ pub mod x86 {
         #![allow(non_upper_case_globals)]
 
         use bitflags::bitflags;
+
+        bitflags! {
+            pub struct FeatureInformationEcx: u32 {
+                const sse3         = 1 << 0;
+                const pclmulqdq    = 1 << 1;
+                const dtes64       = 1 << 2;
+                const monitor      = 1 << 3;
+                const ds_cpl       = 1 << 4;
+                const vmx          = 1 << 5;
+                const smx          = 1 << 6;
+                const eist         = 1 << 7;
+                const tm2          = 1 << 8;
+                const ssse3        = 1 << 9;
+                const cnxt_id      = 1 << 10;
+                const sdbg         = 1 << 11;
+                const fma          = 1 << 12;
+                const cmpxchg16b   = 1 << 13;
+                const xtpr         = 1 << 14;
+                const pdcm         = 1 << 15;
+                const _reserved    = 1 << 16;
+                const pcid         = 1 << 17;
+                const dca          = 1 << 18;
+                const sse4_1       = 1 << 19;
+                const sse4_2       = 1 << 20;
+                const x2apic       = 1 << 21;
+                const movbe        = 1 << 22;
+                const popcnt       = 1 << 23;
+                const tsc_deadline = 1 << 24;
+                const aesni        = 1 << 25;
+                const xsave        = 1 << 26;
+                const osxsave      = 1 << 27;
+                const avx          = 1 << 28;
+                const f16c         = 1 << 29;
+                const rdrand       = 1 << 30;
+                const _unused      = 1 << 31;
+            }
+        }
 
         bitflags! {
             pub struct ExtendedFeaturesEbx: u32 {
@@ -588,8 +713,87 @@ pub mod aarch64 {
 pub mod arm {
     use super::*;
 
-    pub const HELPERS: &[(&str, PcodeOpHelper)] =
-        &[("enableIRQinterrupts", enable_interrupts), ("disableIRQinterrupts", disable_interrupts)];
+    pub const HELPERS: &[(&str, PcodeOpHelper)] = &[
+        ("enableIRQinterrupts", enable_interrupts),
+        ("disableIRQinterrupts", disable_interrupts),
+        // NEON
+        ("VectorCompareEqual", vector_compare_equal),
+        ("VectorPairwiseAdd", vector_pairwise_add),
+        ("VectorAdd", vector_add),
+        ("VectorSub", vector_sub),
+        ("vrev", vrev),
+        ("VectorCopyNarrow", vector_copy_narrow),
+    ];
+
+    fn vector_compare_equal(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
+        let esize = cpu.args[0] as u8;
+        for i in 0..(dst.size / esize) {
+            let a: u64 = cpu.read_dynamic(args[0].slice(i * esize, esize)).zxt();
+            let b: u64 = cpu.read_dynamic(args[1].slice(i * esize, esize)).zxt();
+            cpu.write_trunc(dst.slice(i * esize, esize), if a == b { u64::MAX } else { 0 });
+        }
+    }
+
+    // [a, b] + [c, d] = [a + c, b + d]
+    fn vector_add(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
+        let esize = cpu.args[0] as u8;
+        for i in 0..(dst.size / esize) {
+            let a: u64 = cpu.read_dynamic(args[0].slice(i * esize, esize)).zxt();
+            let b: u64 = cpu.read_dynamic(args[1].slice(i * esize, esize)).zxt();
+            cpu.write_trunc(dst.slice(i * esize, esize), a.wrapping_add(b));
+        }
+    }
+
+    // [a, b] - [c, d] = [a - c, b - d]
+    fn vector_sub(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
+        let esize = cpu.args[0] as u8;
+        for i in 0..(dst.size / esize) {
+            let a: u64 = cpu.read_dynamic(args[0].slice(i * esize, esize)).zxt();
+            let b: u64 = cpu.read_dynamic(args[1].slice(i * esize, esize)).zxt();
+            cpu.write_trunc(dst.slice(i * esize, esize), a.wrapping_sub(b));
+        }
+    }
+
+    // [a, b][c, d] = [a + b, c + d]
+    fn vector_pairwise_add(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
+        let esize = cpu.args[0] as u8;
+
+        let dst_low = dst.slice(0, dst.size / 2);
+        for i in 0..(dst_low.size / esize) {
+            let a: u64 = cpu.read_dynamic(args[0].slice((i * 2) * esize, esize)).zxt();
+            let b: u64 = cpu.read_dynamic(args[0].slice(((i * 2) + 1) * esize, esize)).zxt();
+            cpu.write_trunc(dst_low.slice(i * esize, esize), a.wrapping_add(b));
+        }
+        let dst_high = dst.slice(dst.size / 2, dst.size / 2);
+        for i in 0..(dst_high.size / esize) {
+            let a: u64 = cpu.read_dynamic(args[1].slice((i * 2) * esize, esize)).zxt();
+            let b: u64 = cpu.read_dynamic(args[1].slice(((i * 2) + 1) * esize, esize)).zxt();
+            cpu.write_trunc(dst_high.slice(i * esize, esize), a.wrapping_add(b));
+        }
+    }
+
+    fn vrev(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
+        let esize: u8 = cpu.read_dynamic(args[1]).zxt();
+        for i in 0..(dst.size / esize) {
+            let a: u64 = cpu.read_dynamic(args[0].slice(i * esize, esize)).zxt();
+            cpu.write_trunc(dst.slice(dst.size - (i + 1) * esize, esize), a);
+        }
+    }
+
+    /// Copy the lower bits of a quadword vector to a doubleword vector.
+    /// arg[0] = source, arg[1] = element size
+    ///
+    /// e.g., for element size = 4:
+    /// arg[0] [a:u32, b:32, c:u32, d:u32], dst=[a:u16, b:u16, c:u16, d:u16]
+    fn vector_copy_narrow(cpu: &mut Cpu, dst: VarNode, args: [Value; 2]) {
+        let src = args[0];
+        let esize = cpu.read::<u8>(args[1]);
+        let dst_esize = esize / 2;
+        for i in 0..(src.size() / esize) {
+            let value: u64 = cpu.read_dynamic(src.slice(i * esize, esize)).zxt();
+            cpu.write_trunc(dst.slice(i * dst_esize, dst_esize), value);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/icicle-cpu/src/lifter/msp430.rs
+++ b/icicle-cpu/src/lifter/msp430.rs
@@ -1,6 +1,8 @@
 //! A workaround for missing functionality in the SLEIGH spec for MSP430X.
 
-use crate::{exec::const_eval, lifter::BlockLifter, Arch, Cpu, Exception, ExceptionCode, ValueSource};
+use crate::{
+    exec::const_eval, lifter::BlockLifter, Arch, Cpu, Exception, ExceptionCode, ValueSource,
+};
 
 use super::BlockState;
 
@@ -19,7 +21,7 @@ pub fn status_register_control_patch(cpu: &mut Cpu, lifter: &mut BlockLifter) {
     let check_async = cpu.arch.sleigh.register_user_op(Some("check_sr_control_bits_async"));
     cpu.set_helper(check_async, check_sr_control_bits);
 
-    let status_reg = cpu.arch.sleigh.get_reg("SR").unwrap().var;
+    let status_reg = cpu.arch.sleigh.get_varnode("SR").unwrap();
     let mut const_prop = const_eval::ConstEval::new();
     let handler = move |block: &mut pcode::Block| {
         block.recompute_next_tmp();

--- a/icicle-cpu/src/lifter/optimize.rs
+++ b/icicle-cpu/src/lifter/optimize.rs
@@ -73,7 +73,7 @@ impl Optimizer {
             if let Op::PcodeBranch(label) = stmt.op {
                 // The `None` case here corresponds to jumps to invalid labels, these will trigger
                 // an `InvalidTarget` exception at runtime.
-                if self.labels.get(&label).map_or(false, |target| *target < idx) {
+                if self.labels.get(&label).is_some_and(|target| *target < idx) {
                     self.reachable_labels.insert(label);
                 }
             }
@@ -81,10 +81,9 @@ impl Optimizer {
 
         for stmt in &block.instructions {
             if matches!(stmt.op, Op::InstructionMarker) {
-                // Prevent temporaries from being propagated across instruction boundaries.
-                let mut const_eval = self.const_eval.borrow_mut();
-                const_eval.results.clear();
-                const_eval.inputs.retain(|id, _| self.dead_store_detector.should_persist(*id));
+                self.const_eval
+                    .borrow_mut()
+                    .purge_temporaries(|id| self.dead_store_detector.should_persist(id));
             }
 
             // Check whether we are at a new label.
@@ -472,7 +471,7 @@ impl DeadStoreDetector {
         }
 
         // Check if there is any read that uses this write.
-        if self.live_reads.get(&var.id).map_or(false, |read| read.any_set(var)) {
+        if self.live_reads.get(&var.id).is_some_and(|read| read.any_set(var)) {
             return true;
         }
 

--- a/icicle-cpu/src/lifter/pcodeops.rs
+++ b/icicle-cpu/src/lifter/pcodeops.rs
@@ -225,8 +225,8 @@ pub mod arm {
             injectors.insert(id, Box::new(sleep));
         }
 
-        let ex_addr = match cpu.arch.sleigh.get_reg("exclusive_addr") {
-            Some(reg) => reg.var,
+        let ex_addr = match cpu.arch.sleigh.get_varnode("exclusive_addr") {
+            Some(var) => var,
             None => cpu.arch.sleigh.add_custom_reg("exclusive_addr", 4).unwrap(),
         };
 

--- a/icicle-fuzzing/src/config.rs
+++ b/icicle-fuzzing/src/config.rs
@@ -40,7 +40,7 @@ impl CustomSetup {
                     cpu.exception = Exception::new(ExceptionCode::ExecViolation, addr);
                 }),
                 Hooks::PrintChar(reg) => {
-                    let reg = vm.cpu.arch.sleigh.get_reg(reg).unwrap().var;
+                    let reg = vm.cpu.arch.sleigh.get_varnode(reg).unwrap();
                     vm.hook_address(addr, move |cpu: &mut icicle_vm::cpu::Cpu, _| {
                         let char = cpu.read_var::<u32>(reg);
                         print!("{}", char as u8 as char);
@@ -48,8 +48,8 @@ impl CustomSetup {
                     });
                 }
                 Hooks::PrintStrSlice(data_reg, len_reg) => {
-                    let data = vm.cpu.arch.sleigh.get_reg(data_reg).unwrap().var;
-                    let len = vm.cpu.arch.sleigh.get_reg(len_reg).unwrap().var;
+                    let data = vm.cpu.arch.sleigh.get_varnode(data_reg).unwrap();
+                    let len = vm.cpu.arch.sleigh.get_varnode(len_reg).unwrap();
 
                     let mut buf = vec![];
                     vm.hook_address(addr, move |cpu: &mut icicle_vm::cpu::Cpu, _| {
@@ -62,7 +62,7 @@ impl CustomSetup {
                     });
                 }
                 Hooks::PrintCstr(reg) => {
-                    let reg = vm.cpu.arch.sleigh.get_reg(reg).unwrap().var;
+                    let reg = vm.cpu.arch.sleigh.get_varnode(reg).unwrap();
                     let mut buf = [0; 64];
                     vm.hook_address(addr, move |cpu: &mut icicle_vm::cpu::Cpu, _| {
                         let ptr = cpu.read_var::<u32>(reg) as u64;
@@ -71,7 +71,7 @@ impl CustomSetup {
                     });
                 }
                 Hooks::PrintLnCstr(reg) => {
-                    let reg = vm.cpu.arch.sleigh.get_reg(reg).unwrap().var;
+                    let reg = vm.cpu.arch.sleigh.get_varnode(reg).unwrap();
                     let mut buf = [0; 64];
                     vm.hook_address(addr, move |cpu: &mut icicle_vm::cpu::Cpu, _| {
                         let ptr = cpu.read_var::<u32>(reg) as u64;
@@ -96,9 +96,8 @@ impl CustomSetup {
                     .cpu
                     .arch
                     .sleigh
-                    .get_reg(name)
-                    .ok_or_else(|| anyhow::format_err!("unknown register: {name}"))?
-                    .var;
+                    .get_varnode(name)
+                    .ok_or_else(|| anyhow::format_err!("unknown register: {name}"))?;
                 entry.location = Location::VarNode(var);
             }
             if let Location::Symbol(sym) = &entry.location {

--- a/icicle-fuzzing/src/msp430.rs
+++ b/icicle-fuzzing/src/msp430.rs
@@ -69,7 +69,7 @@ impl crate::FuzzTarget for RandomIoTarget {
     }
 
     fn initialize_vm(&mut self, config: &FuzzConfig, vm: &mut icicle_vm::Vm) -> anyhow::Result<()> {
-        if let Some(var) = vm.cpu.arch.sleigh.get_reg("afl.prev_pc").map(|x| x.var) {
+        if let Some(var) = vm.cpu.arch.sleigh.get_varnode("afl.prev_pc") {
             let env = vm.env_mut::<Msp430>().unwrap();
             env.afl_prev_pc = Some(var);
         }

--- a/icicle-gdb/src/arch.rs
+++ b/icicle-gdb/src/arch.rs
@@ -41,7 +41,7 @@ impl DynamicTarget for IcicleX64 {
 
     #[rustfmt::skip]
     fn new(cpu: &Cpu) -> Self {
-        let r = |name: &str| cpu.arch.sleigh.get_reg(name).unwrap().var;
+        let r = |name: &str| cpu.arch.sleigh.get_varnode(name).unwrap();
         Self {
             regs: [
                 r("RAX"), r("RBX"), r("RCX"), r("RDX"), r("RSI"), r("RDI"),
@@ -110,7 +110,7 @@ impl DynamicTarget for IcicleMips32 {
 
     #[rustfmt::skip]
     fn new(cpu: &Cpu) -> Self {
-        let r = |name: &str| cpu.arch.sleigh.get_reg(name).unwrap().var;
+        let r = |name: &str| cpu.arch.sleigh.get_varnode(name).unwrap();
         Self {
             r: [
                 r("zero"), r("at"), r("v0"), r("v1"),
@@ -167,7 +167,7 @@ impl DynamicTarget for IcicleArm {
 
     #[rustfmt::skip]
     fn new(cpu: &Cpu) -> Self {
-        let r = |name: &str| cpu.arch.sleigh.get_reg(name).unwrap().var;
+        let r = |name: &str| cpu.arch.sleigh.get_varnode(name).unwrap();
         Self {
             r: [
                 r("r0"), r("r1"), r("r2"), r("r3"), r("r4"), r("r5"), r("r6"), r("r7"),
@@ -206,7 +206,7 @@ impl DynamicTarget for IcicleMsp430 {
 
     #[rustfmt::skip]
     fn new(cpu: &Cpu) -> Self {
-        let r = |name: &str| cpu.arch.sleigh.get_reg(name).unwrap().var;
+        let r = |name: &str| cpu.arch.sleigh.get_varnode(name).unwrap();
         Self {
             pc: r("PC"),
             sp: r("SP"),

--- a/icicle-gdb/src/stub.rs
+++ b/icicle-gdb/src/stub.rs
@@ -396,8 +396,8 @@ impl<T: DynamicTarget> ext::monitor_cmd::MonitorCmd for VmState<T> {
             }
             Some("lookup-varnode") => {
                 if let Some(name) = parts.next() {
-                    match self.vm.cpu.arch.sleigh.get_reg(name) {
-                        Some(var) => gdbstub::outputln!(out, "{:?}", var.var),
+                    match self.vm.cpu.arch.sleigh.get_varnode(name) {
+                        Some(var) => gdbstub::outputln!(out, "{:?}", var),
                         None => gdbstub::outputln!(out, "unknown register"),
                     }
                 }
@@ -409,9 +409,9 @@ impl<T: DynamicTarget> ext::monitor_cmd::MonitorCmd for VmState<T> {
 
             Some("varnode") => {
                 if let Some(name) = parts.next() {
-                    match self.vm.cpu.arch.sleigh.get_reg(name) {
+                    match self.vm.cpu.arch.sleigh.get_varnode(name) {
                         Some(var) => {
-                            let value = self.vm.cpu.read_reg(var.var);
+                            let value = self.vm.cpu.read_reg(var);
                             gdbstub::outputln!(out, "{name} = {value:#x}")
                         }
                         None => gdbstub::outputln!(out, "unknown register"),

--- a/icicle-jit/src/translate/ops.rs
+++ b/icicle-jit/src/translate/ops.rs
@@ -707,9 +707,9 @@ mod test {
             let cpu = Cpu::new_boxed(Arch::none());
             let mut jit = crate::JIT::new(&cpu);
 
-            let a = cpu.arch.sleigh.get_reg("a").unwrap().var.slice(0, 4);
-            let b = cpu.arch.sleigh.get_reg("b").unwrap().var.slice(0, 4);
-            let out = cpu.arch.sleigh.get_reg("c").unwrap().var.slice(0, out_size);
+            let a = cpu.arch.sleigh.get_varnode("a").unwrap().slice(0, 4);
+            let b = cpu.arch.sleigh.get_varnode("b").unwrap().slice(0, 4);
+            let out = cpu.arch.sleigh.get_varnode("c").unwrap().slice(0, out_size);
 
             let inst = pcode::Instruction::from((out, op, (a, b)));
             let jit_fn = compile_instruction(&mut jit, inst);

--- a/icicle-linux/src/arch/aarch64.rs
+++ b/icicle-linux/src/arch/aarch64.rs
@@ -7,7 +7,7 @@ pub struct Aarch64 {
 
 impl Aarch64 {
     pub fn new(arch: &icicle_cpu::Arch) -> Self {
-        let r = |name: &str| arch.sleigh.get_reg(name).unwrap().var;
+        let r = |name: &str| arch.sleigh.get_varnode(name).unwrap();
         let args = [r("x8"), r("x0"), r("x1"), r("x2"), r("x3"), r("x4"), r("x5")];
         Self { args }
     }

--- a/icicle-linux/src/arch/mips.rs
+++ b/icicle-linux/src/arch/mips.rs
@@ -49,7 +49,7 @@ pub struct Mips32 {
 impl Mips32 {
     #[rustfmt::skip]
     pub fn new(arch: &icicle_cpu::Arch) -> Self {
-        let r = |name: &str| arch.sleigh.get_reg(name).unwrap().var;
+        let r = |name: &str| arch.sleigh.get_varnode(name).unwrap();
         Self {
             regs: [
                 r("zero"), r("at"), r("v0"), r("v1"),

--- a/icicle-linux/src/arch/riscv64.rs
+++ b/icicle-linux/src/arch/riscv64.rs
@@ -7,7 +7,7 @@ pub struct Riscv64 {
 
 impl Riscv64 {
     pub fn new(arch: &icicle_cpu::Arch) -> Self {
-        let r = |name: &str| arch.sleigh.get_reg(name).unwrap().var;
+        let r = |name: &str| arch.sleigh.get_varnode(name).unwrap();
         let args = [r("a7"), r("a0"), r("a1"), r("a2"), r("a3"), r("a4"), r("a5")];
         Self { args }
     }

--- a/icicle-linux/src/arch/x86.rs
+++ b/icicle-linux/src/arch/x86.rs
@@ -42,7 +42,7 @@ pub mod x64 {
 
     impl X64 {
         pub fn new(arch: &icicle_cpu::Arch) -> Self {
-            let r = |name: &str| arch.sleigh.get_reg(name).unwrap().var;
+            let r = |name: &str| arch.sleigh.get_varnode(name).unwrap();
             Self {
                 rax: r("RAX"),
                 rdi: r("RDI"),
@@ -101,7 +101,7 @@ pub mod i386 {
 
     impl I386 {
         pub fn new(arch: &icicle_cpu::Arch) -> Self {
-            let r = |name: &str| arch.sleigh.get_reg(name).unwrap().var;
+            let r = |name: &str| arch.sleigh.get_varnode(name).unwrap();
             Self {
                 eax: r("EAX"),
                 ebx: r("EBX"),

--- a/icicle-linux/src/sys/syscall.rs
+++ b/icicle-linux/src/sys/syscall.rs
@@ -369,7 +369,7 @@ pub fn pipe_m<C: LinuxCpu>(ctx: &mut Ctx<C>) -> LinuxResult {
     };
 
     // This has a special calling convention on mips.
-    let v1 = ctx.cpu.sleigh().get_reg("v1").unwrap().var;
+    let v1 = ctx.cpu.sleigh().get_varnode("v1").unwrap();
     ctx.cpu.write_var(v1, fd1);
 
     Ok(fd0)
@@ -1475,12 +1475,12 @@ pub fn arch_prctl_x64<C: LinuxCpu>(ctx: &mut Ctx<C>, code: u64, addr: u64) -> Li
             Err(errno::EINVAL.into())
         }
         x86::arch::SET_FS => {
-            let fs_offset = ctx.cpu.sleigh().get_reg("FS_OFFSET").unwrap().var;
+            let fs_offset = ctx.cpu.sleigh().get_varnode("FS_OFFSET").unwrap();
             ctx.cpu.write_var(fs_offset, addr);
             Ok(0)
         }
         x86::arch::SET_GS => {
-            let gs_offset = ctx.cpu.sleigh().get_reg("GS_OFFSET").unwrap().var;
+            let gs_offset = ctx.cpu.sleigh().get_varnode("GS_OFFSET").unwrap();
             ctx.cpu.write_var(gs_offset, addr);
             Ok(0)
         }
@@ -1641,7 +1641,7 @@ pub fn set_tid_address<C: LinuxCpu>(_ctx: &mut Ctx<C>, _tidptr: u64) -> LinuxRes
 }
 
 pub fn set_thread_area_mips<C: LinuxCpu>(ctx: &mut Ctx<C>, addr: u64) -> LinuxResult {
-    let user_local = ctx.cpu.sleigh().get_reg("HW_ULR").unwrap().var;
+    let user_local = ctx.cpu.sleigh().get_varnode("HW_ULR").unwrap();
     ctx.cpu.write_var(user_local, addr);
     Ok(0)
 }
@@ -1666,7 +1666,7 @@ pub fn set_thread_area_x86<C: LinuxCpu>(ctx: &mut Ctx<C>, user_desc: u64) -> Lin
 
     // Write the entry to the GDT at position 12 (an arbitary position to use for now)
     let gdb_descriptor: u32 = 12;
-    let gdtr = ctx.cpu.sleigh().get_reg("GDTR").unwrap().var;
+    let gdtr = ctx.cpu.sleigh().get_varnode("GDTR").unwrap();
     let gdt_addr: u64 = ctx.cpu.read_var(gdtr);
     ctx.cpu.mem().write_bytes(gdt_addr + gdb_descriptor as u64 * 8, &entry.to_bytes())?;
 

--- a/icicle-test/src/tester.rs
+++ b/icicle-test/src/tester.rs
@@ -162,7 +162,12 @@ impl Tester for icicle_vm::Vm {
                 let _ = self.cpu.mem.read_u8(*addr, perm::NONE)?;
             }
             &Assignment::Register { name, value } => {
-                let varnode = self.cpu.arch.sleigh.get_reg(name).unwrap().var;
+                let varnode = self
+                    .cpu
+                    .arch
+                    .sleigh
+                    .get_varnode(name)
+                    .ok_or_else(|| anyhow::format_err!("Register: {name} not found"))?;
                 // @fixme: make write_trunc work with reg handlers?
                 if varnode.size <= 8 {
                     self.cpu.write_reg(varnode, value as u64)
@@ -187,7 +192,12 @@ impl Tester for icicle_vm::Vm {
                 );
             }
             &Assignment::Register { name, value } => {
-                let varnode = self.cpu.arch.sleigh.get_reg(name).unwrap().var;
+                let varnode = self
+                    .cpu
+                    .arch
+                    .sleigh
+                    .get_varnode(name)
+                    .ok_or_else(|| anyhow::format_err!("Register: {name} not found"))?;
 
                 let tmp = if varnode.size <= 8 {
                     self.cpu.read_reg(varnode) as u128

--- a/icicle-vm/src/debug.rs
+++ b/icicle-vm/src/debug.rs
@@ -220,8 +220,8 @@ pub fn callstack_from_frame_pointer(vm: &mut Vm) -> Option<Vec<u64>> {
     let reg_sp = vm.cpu.arch.reg_sp;
     let reg_pc = vm.cpu.arch.reg_pc;
     let reg_bp = match vm.cpu.arch.triple.architecture {
-        target_lexicon::Architecture::X86_64 => vm.cpu.arch.sleigh.get_reg("RBP")?.var,
-        target_lexicon::Architecture::Arm(_) => vm.cpu.arch.sleigh.get_reg("r11")?.var,
+        target_lexicon::Architecture::X86_64 => vm.cpu.arch.sleigh.get_varnode("RBP")?,
+        target_lexicon::Architecture::Arm(_) => vm.cpu.arch.sleigh.get_varnode("r11")?,
         _ => return None,
     };
 
@@ -263,7 +263,7 @@ pub fn callstack_from_frame_pointer(vm: &mut Vm) -> Option<Vec<u64>> {
 
 fn get_link_register(vm: &Vm) -> Option<pcode::VarNode> {
     match vm.cpu.arch.triple.architecture {
-        target_lexicon::Architecture::Arm(_) => Some(vm.cpu.arch.sleigh.get_reg("lr")?.var),
+        target_lexicon::Architecture::Arm(_) => vm.cpu.arch.sleigh.get_varnode("lr"),
         // @todo: add other architectures.
         _ => None,
     }
@@ -363,7 +363,7 @@ pub fn get_debug_regs(cpu: &crate::Cpu) -> Vec<pcode::VarNode> {
         ][..],
         _ => &[][..],
     };
-    names.iter().map(|name| cpu.arch.sleigh.get_reg(name).unwrap().var).collect()
+    names.iter().map(|name| cpu.arch.sleigh.get_varnode(name).unwrap()).collect()
 }
 
 pub fn log_write(
@@ -398,8 +398,8 @@ pub fn log_regs(
     let regs: Vec<_> = reglist
         .iter()
         .map(AsRef::as_ref)
-        .flat_map(|reg| match vm.cpu.arch.sleigh.get_reg(reg) {
-            Some(reg) => Some(reg.var),
+        .flat_map(|reg| match vm.cpu.arch.sleigh.get_varnode(reg) {
+            Some(reg) => Some(reg),
             None => {
                 tracing::error!("Unknown register: {reg}");
                 None

--- a/icicle-vm/src/msp430/env.rs
+++ b/icicle-vm/src/msp430/env.rs
@@ -99,8 +99,8 @@ impl Msp430 {
         Ok(Self {
             interrupts: Rc::new(interrupts(&mcu)),
             interrupt_rng: XorShiftRng::new(0x1234),
-            sp: cpu.arch.sleigh.get_reg("SP").unwrap().var,
-            sr: cpu.arch.sleigh.get_reg("SR").unwrap().var,
+            sp: cpu.arch.sleigh.get_varnode("SP").unwrap(),
+            sr: cpu.arch.sleigh.get_varnode("SR").unwrap(),
             afl_prev_pc: None,
             interrupt_interval: config.interrupt_interval,
             next_interrupt: config.interrupt_interval,

--- a/icicle-vm/src/msp430/mod.rs
+++ b/icicle-vm/src/msp430/mod.rs
@@ -23,7 +23,7 @@ pub struct StatusRegHandler {
 
 impl StatusRegHandler {
     pub fn new(sleigh: &SleighData) -> Self {
-        let r = |name: &str| sleigh.get_reg(name).unwrap().var;
+        let r = |name: &str| sleigh.get_varnode(name).unwrap();
         Self { cf: r("CF"), zf: r("ZF"), sf: r("SF"), of: r("OF"), ie: r("IE"), sr: r("SR") }
     }
 }

--- a/sleigh/sleigh-compile/src/constructor/mod.rs
+++ b/sleigh/sleigh-compile/src/constructor/mod.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 
 use sleigh_parse::ast;
 use sleigh_runtime::{
+    DecodeAction, Field, PatternExprOp, Token,
     matcher::Constraint,
     semantics::{Local, PcodeTmp, SemanticAction, ValueSize},
-    DecodeAction, Field, PatternExprOp, Token,
 };
 
 use crate::{
-    symbols::{Attachment, SymbolKind, SymbolTable, TableId},
     Context,
+    symbols::{Attachment, SymbolKind, SymbolTable, TableId},
 };
 
 pub use self::semantics::Semantics;
@@ -137,6 +137,9 @@ pub(crate) struct Scope<'a> {
 
     /// Keeps track of the mapping between labels and their IDs
     labels: HashMap<ast::Ident, PcodeLabel>,
+
+    /// Keeps track of the next label ID
+    next_label_id: u16,
 }
 
 impl<'a> Scope<'a> {
@@ -149,6 +152,7 @@ impl<'a> Scope<'a> {
             tokens: HashMap::new(),
             mapping: HashMap::new(),
             labels: HashMap::new(),
+            next_label_id: 0,
         }
     }
 
@@ -237,11 +241,10 @@ impl<'a> Scope<'a> {
     }
 
     pub fn get_or_insert_label(&mut self, name: &ast::Ident) -> &mut PcodeLabel {
-        let next_label: u16 = self.labels.len().try_into().unwrap();
-        self.labels.entry(name.to_owned()).or_insert_with(|| PcodeLabel {
-            id: next_label,
-            defined: false,
-            back_edge: false,
+        let next_label = self.next_label_id;
+        self.labels.entry(name.to_owned()).or_insert_with(|| {
+            self.next_label_id = self.next_label_id.checked_add(1).unwrap();
+            PcodeLabel { id: next_label, defined: false, back_edge: false }
         })
     }
 

--- a/sleigh/sleigh-compile/src/lib.rs
+++ b/sleigh/sleigh-compile/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::Path};
 
-use sleigh_parse::{ast, Parser};
+use sleigh_parse::{Parser, ast};
 use sleigh_runtime::{
     AttachmentIndex, Constructor, ConstructorDebugInfo, DecodeAction, DisplaySegment,
     NamedRegister, RegisterAlias, RegisterAttachment, SleighData, StrIndex,
@@ -16,6 +16,9 @@ mod symbols;
 
 #[cfg(feature = "ldefs")]
 pub mod ldef;
+
+#[cfg(feature = "ldefs")]
+pub use crate::ldef::SleighLanguageBuilder;
 
 #[cfg(feature = "ldefs")]
 pub fn from_ldef_path(
@@ -126,69 +129,65 @@ pub fn build_inner(mut parser: Parser, verbose: bool) -> Result<SleighData, Stri
             // Fix offsets for big-endian registers.
             let mut offset = reg.offset;
             if ctx.data.big_endian {
-                local_offset = parent_reg.var.size - local_offset - reg.size as u8;
+                local_offset = parent_reg.get_raw_var().size - local_offset - reg.size as u8;
                 offset = parent_reg.offset + local_offset as u32;
             }
 
-            // Map varnodes refering to the current register to the subslice of the parent register
-            // that this register overlaps.
-            let var = parent_reg
-                .get_var(local_offset, reg.size as u8)
-                .ok_or_else(|| format!("Internal error: {name_str} crosses 128-bit boundary"))?;
-            ctx.data.named_registers[idx] = NamedRegister { name, var, offset };
+            // Map varnodes refering to the current register to the subslice of the parent
+            // register that this register overlaps.
+            let var = parent_reg.get_raw_var().try_slice(local_offset, reg.size as u8).ok_or_else(
+                || {
+                    format!(
+                        "{name_str} partially overlaps with {}",
+                        ctx.data.get_str(parent_reg.name)
+                    )
+                },
+            )?;
+            ctx.data.named_registers[idx] = NamedRegister::new(name, offset, var);
 
             // Add the current register as an alias in the parent register (used for the display
-            // implementation)
-            ctx.data.registers[var.id as usize].aliases.push(RegisterAlias {
-                offset: var.offset as u16,
-                size: reg.size,
-                name,
-            });
-            continue;
+            // implementation of individual varnodes). Values larger than 128 bits (the `None`
+            // case) can never be stored in a single register so are never added as aliases.
+            if let Some(var) = ctx.data.named_registers[idx].get_var() {
+                ctx.data.registers[var.id as usize].aliases.push(RegisterAlias {
+                    offset: var.offset as u16,
+                    size: var.size as u16,
+                    name,
+                });
+            }
         }
+        else {
+            // Note: `reg.size` can be larger than 128 bits which is larger than the emulator
+            // supports we handle this by creating new registers for each 128-bit slice (see below)
+            // and fix up the IDs when extracting subslices (see: NamedRegister::get_var).
+            let reg_id = ctx.data.registers.len().try_into().unwrap();
+            ctx.data.named_registers[idx] =
+                NamedRegister::new(name, reg.offset, pcode::VarNode::new(reg_id, reg.size as u8));
 
-        // Note: `reg.size` can be larger than 128 bits which is larger than the emulator supports
-        // we handle this by creating new registers for each 128-bit slice (see below) and fix up
-        // the IDs when extracting subslices (see: NamedRegister::get_var).
-        let reg_id = ctx.data.registers.len().try_into().unwrap();
-        ctx.data.named_registers[idx] = NamedRegister {
-            name,
-            var: pcode::VarNode::new(reg_id, reg.size as u8),
-            offset: reg.offset,
-        };
-
-        // Map all the bytes within this range to the register.
-        for byte in 0..reg.size {
-            let varnode_offset = reg.offset + byte as u32;
-            ctx.data.register_mapping.insert(varnode_offset, (idx as u32, byte as u8));
-        }
-
-        // We only support operating on registers that are at most 128-bits. This is only an issue
-        // when dealing with vector operations (e.g. AVX, NEON). To handle this we need to split the
-        // register into multiple smaller registers.
-        for i in (0..reg.size).step_by(16) {
-            let size = std::cmp::min(reg.size - i, 16) as u8;
-
-            if i != 0 {
-                name = ctx.add_string(&format!("{}_{}", name_str, i));
+            // Map all the bytes within this range to the register.
+            for byte in 0..reg.size {
+                let varnode_offset = reg.offset + byte as u32;
+                ctx.data.register_mapping.insert(varnode_offset, (idx as u32, byte as u8));
             }
 
-            ctx.data.registers.push(sleigh_runtime::RegisterInfo {
-                name,
-                size,
-                offset: reg.offset + i as u32,
-                aliases: vec![],
-            });
-        }
-    }
+            // We only support operating on registers that are at most 128-bits. This is only an
+            // issue when dealing with vector operations (e.g. AVX, NEON). To handle
+            // this we need to split the register into multiple smaller registers.
+            for i in (0..reg.size).step_by(16) {
+                let size = std::cmp::min(reg.size - i, 16) as u8;
 
-    // Register additional varnodes for saved temporaries
-    for i in 0..8 {
-        let var = ctx
-            .data
-            .add_custom_reg(&format!("$tmp{i}"), 16)
-            .ok_or_else(|| format!("failed to reserve varnode for temporary"))?;
-        ctx.data.saved_tmps.push(var);
+                if i != 0 {
+                    name = ctx.add_string(&format!("{name_str}_{i}"));
+                }
+
+                ctx.data.registers.push(sleigh_runtime::RegisterInfo {
+                    name,
+                    size,
+                    offset: reg.offset + i as u32,
+                    aliases: vec![],
+                });
+            }
+        }
     }
 
     for attachment in &symbols.attachments {
@@ -218,7 +217,7 @@ pub fn build_inner(mut parser: Parser, verbose: bool) -> Result<SleighData, Stri
             }
             symbols::Attachment::Value(values) => {
                 let start = ctx.data.attached_values.len() as u32;
-                ctx.data.attached_values.extend(values.iter().map(|v| *v as i64));
+                ctx.data.attached_values.extend(values.iter().copied());
                 let end = ctx.data.attached_values.len() as u32;
                 ctx.data.attachments.push(AttachmentIndex::Value((start, end)));
             }
@@ -351,7 +350,7 @@ fn resolve_item(ctx: &mut Context, syms: &mut SymbolTable, item: ast::Item) -> R
 
             if let Err(e) = syms.define_constructor(ctx, &constructor) {
                 if ctx.verbose {
-                    eprintln!("[WARNING] {}", e);
+                    eprintln!("[WARNING] {e}");
                 }
             }
         }

--- a/sleigh/sleigh-parse/src/parser.rs
+++ b/sleigh/sleigh-parse/src/parser.rs
@@ -1,10 +1,11 @@
 use std::collections::{HashMap, VecDeque};
 
 use crate::{
+    Error, ErrorExt, Span,
     ast::{self, ExprTable, VarSize},
     input::Input,
     lexer::{self, Lexer, SourceId, Token, TokenKind},
-    preprocessor, Error, ErrorExt, Span,
+    preprocessor,
 };
 
 /// Limits the maximum macro expansion depth (used to detect cycles).
@@ -97,7 +98,7 @@ pub struct Parser {
 }
 
 impl Parser {
-    fn new<I: Input + 'static>(input: I, defines: &[impl AsRef<str>]) -> Self {
+    pub fn new<I: Input + 'static>(input: I, defines: &[impl AsRef<str>]) -> Self {
         let mut parser = Self {
             input: Box::new(input),
             sources: vec![],
@@ -365,7 +366,7 @@ impl Parser {
         let content = self
             .input
             .open(&name)
-            .map_err(|e| self.error(format!("failed to open `{}`: {}", name, e)))?;
+            .map_err(|e| self.error(format!("failed to open `{name}`: {e}")))?;
         let file = self.load_content(name, content);
 
         self.expand_here(file)
@@ -454,7 +455,7 @@ impl Parser {
     pub(crate) fn parse_size(&mut self) -> Result<VarSize, Error> {
         let token = self.expect(TokenKind::Number)?;
         let value = self.get_str(token);
-        value.parse().map_err(|e| self.error(format!("invalid u8: {}", e)))
+        value.parse().map_err(|e| self.error(format!("invalid u8: {e}")))
     }
 
     /// Parses an integer used for defining the size of a field or space. Unlike `parse_size` this
@@ -496,8 +497,8 @@ impl<'a> std::fmt::Display for ErrorFormatter<'a> {
         writeln!(f, "{}:{}:{} error: {}", src.name, line + 1, col, self.error.message)?;
 
         let mut span_str = String::new();
-        span_str.extend(iter::repeat(' ').take(span.start as usize - line_start));
-        span_str.extend(iter::repeat('^').take(self.error.span.len().min(line_end - line_start)));
+        span_str.extend(iter::repeat_n(' ', span.start as usize - line_start));
+        span_str.extend(iter::repeat_n('^', self.error.span.len().min(line_end - line_start)));
 
         writeln!(f, "{}\n{}", &src.content[line_start..line_end], span_str)?;
 
@@ -580,7 +581,7 @@ impl Parse for u64 {
 
         Ok(Some(
             u64::from_str_radix(value, radix)
-                .map_err(|e| token.error(format!("invalid number: {}", e)))?,
+                .map_err(|e| token.error(format!("invalid number: {e}")))?,
         ))
     }
 }
@@ -593,6 +594,46 @@ impl Parse for ast::Ident {
             Some(token) => Ok(Some(Self(p.intern_token(token)))),
             None => Ok(None),
         }
+    }
+}
+
+/// Keywords are often contextual in SLEIGH, so in many cases we allow both identifiers and
+/// keywords.
+pub fn parse_ident_or_keyword(p: &mut Parser) -> Result<Option<ast::Ident>, Error> {
+    let token = p.peek();
+    match token.kind {
+        TokenKind::Ident => {
+            _ = p.next();
+            Ok(Some(ast::Ident(p.intern_token(token))))
+        }
+
+        TokenKind::Defined
+        | TokenKind::Define
+        | TokenKind::Alignment
+        | TokenKind::Endian
+        | TokenKind::BitRange
+        | TokenKind::Space
+        | TokenKind::Default
+        | TokenKind::PcodeOp
+        | TokenKind::Attach
+        | TokenKind::Token
+        | TokenKind::Context
+        | TokenKind::Variables
+        | TokenKind::Names
+        | TokenKind::Values
+        | TokenKind::Signed
+        | TokenKind::Hex
+        | TokenKind::Dec
+        | TokenKind::NoFlow
+        | TokenKind::Unimpl
+        // | TokenKind::With // Not allowed by Ghidra
+        | TokenKind::Macro
+        | TokenKind::GlobalSet
+        | TokenKind::Is => {
+            _ = p.next();
+            Ok(Some(ast::Ident(p.intern_token(token))))
+        }
+        _ => Ok(None),
     }
 }
 
@@ -667,7 +708,7 @@ impl Parse for ast::EndianKind {
         let ast::Ident(ident) = parse_kw_value(p, TokenKind::Endian)?;
         let str = p.interner.get(ident);
         Some(str.parse().map_err(|_| Error {
-            message: format!("Unexpected endian kind: {}", str),
+            message: format!("Unexpected endian kind: {str}"),
             span: Span::new(start, p.current_span()),
             cause: None,
         }))
@@ -723,7 +764,7 @@ impl Parse for ast::SpaceKind {
             "ram_space" => Ok(Some(Self::RamSpace)),
             "rom_space" => Ok(Some(Self::RomSpace)),
             "register_space" => Ok(Some(Self::RegisterSpace)),
-            other => Err(p.error(format!("invalid space type: {}", other))),
+            other => Err(p.error(format!("invalid space type: {other}"))),
         }
     }
 }
@@ -949,20 +990,7 @@ impl Parse for ast::Constructor {
         let constraint = p.parse()?;
         let disasm_actions = p.try_parse::<BrackedList<_>>()?.map_or(vec![], |x| x.0);
 
-        let token = p.peek();
-        let semantics = match token.kind {
-            TokenKind::Unimpl => {
-                p.expect(TokenKind::Unimpl)?;
-                vec![ast::Statement::Unimplemented]
-            }
-            TokenKind::LeftBrace => {
-                p.expect(TokenKind::LeftBrace)?;
-                let statements = parse_sequence_until_v2(p, TokenKind::RightBrace)?;
-                p.expect(TokenKind::RightBrace)?;
-                statements
-            }
-            _ => return Err(p.error_unexpected(token, &[TokenKind::Unimpl, TokenKind::LeftBrace])),
-        };
+        let semantics = parse_semantics_section(p)?;
 
         Ok(Some(ast::Constructor {
             table,
@@ -973,6 +1001,23 @@ impl Parse for ast::Constructor {
             semantics,
             span: Span::new(start, p.current_span()),
         }))
+    }
+}
+
+fn parse_semantics_section(p: &mut Parser) -> Result<Vec<ast::Statement>, Error> {
+    let token = p.peek();
+    match token.kind {
+        TokenKind::Unimpl => {
+            p.expect(TokenKind::Unimpl)?;
+            Ok(vec![ast::Statement::Unimplemented])
+        }
+        TokenKind::LeftBrace => {
+            p.expect(TokenKind::LeftBrace)?;
+            let statements = parse_sequence_until_v2(p, TokenKind::RightBrace)?;
+            p.expect(TokenKind::RightBrace)?;
+            Ok(statements)
+        }
+        _ => Err(p.error_unexpected(token, &[TokenKind::Unimpl, TokenKind::LeftBrace])),
     }
 }
 
@@ -1028,8 +1073,22 @@ fn parse_constraint(p: &mut Parser) -> Result<ast::ConstraintExpr, Error> {
             ast::ConstraintExpr::ExtendLeft(Box::new(parse_constraint(p)?))
         }
 
-        TokenKind::Ident => {
-            let ident = p.parse::<ast::Ident>()?;
+        TokenKind::LeftParen => {
+            p.expect(TokenKind::LeftParen)?;
+            let inner = parse_constraint_expr_bp(p, 0)?;
+            p.expect(TokenKind::RightParen)?;
+            inner
+        }
+
+        _ => {
+            let Some(ident) = parse_ident_or_keyword(p)?
+            else {
+                return Err(p.error_unexpected(token, &[
+                    TokenKind::Ident,
+                    TokenKind::TripleDot,
+                    TokenKind::LeftParen,
+                ]));
+            };
             match p.peek().kind {
                 TokenKind::ExclamationMark => {
                     p.expect(TokenKind::ExclamationMark)?;
@@ -1063,15 +1122,6 @@ fn parse_constraint(p: &mut Parser) -> Result<ast::ConstraintExpr, Error> {
                 _ => ast::ConstraintExpr::Ident(ident),
             }
         }
-
-        TokenKind::LeftParen => {
-            p.expect(TokenKind::LeftParen)?;
-            let inner = parse_constraint_expr_bp(p, 0)?;
-            p.expect(TokenKind::RightParen)?;
-            inner
-        }
-
-        _ => return Err(p.error_unexpected(token, &[TokenKind::Ident, TokenKind::LeftParen])),
     };
 
     if p.check(TokenKind::TripleDot) {
@@ -1184,21 +1234,18 @@ impl Parse for ast::Statement {
                 ast::Statement::Branch { dst: p.parse()?, hint: ast::BranchHint::Return }
             }
             TokenKind::LessThan => {
-                p.expect(TokenKind::LessThan)?;
-                let label = p.parse()?;
-                p.expect(TokenKind::GreaterThan)?;
+                let label = parse_label(p)?;
                 // Labels do not end with a semi-colon so exit early here
                 return Ok(Some(ast::Statement::Label { label }));
             }
-            TokenKind::Ident if p.check_nth(1, TokenKind::LeftParen) => {
-                ast::Statement::Call(p.parse()?)
-            }
-            _ => {
-                let lhs = parse_pcode_term(p)?;
-                p.expect(TokenKind::Equal)?;
-                let rhs = p.parse()?;
-                ast::Statement::Copy { to: lhs, from: rhs }
-            }
+            _ => match parse_pcode_term(p)? {
+                ast::PcodeExpr::Call(pcode_call) => ast::Statement::Call(pcode_call),
+                lhs => {
+                    p.expect(TokenKind::Equal)?;
+                    let rhs = p.parse()?;
+                    ast::Statement::Copy { to: lhs, from: rhs }
+                }
+            },
         };
         p.expect(TokenKind::SemiColon)?;
         Ok(Some(stmt))
@@ -1222,28 +1269,23 @@ fn parse_deref(
     Ok((space, size, pointer))
 }
 
-impl Parse for ast::PcodeCall {
-    const NAME: &'static str = "Call";
+fn parse_call_args(p: &mut Parser) -> Result<Vec<ast::PcodeExpr>, Error> {
+    p.expect(TokenKind::LeftParen)?;
 
-    fn try_parse(p: &mut Parser) -> Result<Option<Self>, Error> {
-        let name = p.parse()?;
-        p.expect(TokenKind::LeftParen)?;
+    let mut prev_comma = true;
+    let args = parse_sequence(p, |p| {
+        if !prev_comma || p.check(TokenKind::RightParen) {
+            return Ok(None);
+        }
 
-        let mut prev_comma = true;
-        let args = parse_sequence(p, |p| {
-            if !prev_comma || p.check(TokenKind::RightParen) {
-                return Ok(None);
-            }
+        let expr = p.parse()?;
+        prev_comma = p.bump_if(TokenKind::Comma)?.is_some();
 
-            let expr = p.parse()?;
-            prev_comma = p.bump_if(TokenKind::Comma)?.is_some();
+        Ok(Some(expr))
+    })?;
+    p.expect(TokenKind::RightParen)?;
 
-            Ok(Some(expr))
-        })?;
-        p.expect(TokenKind::RightParen)?;
-
-        Ok(Some(ast::PcodeCall { name, args }))
-    }
+    Ok(args)
 }
 
 impl Parse for ast::BranchDst {
@@ -1258,15 +1300,22 @@ impl Parse for ast::BranchDst {
                 p.expect(TokenKind::RightBracket)?;
                 Some(ast::BranchDst::Indirect(offset))
             }
-            TokenKind::LessThan => {
-                p.expect(TokenKind::LessThan)?;
-                let label = p.parse()?;
-                p.expect(TokenKind::GreaterThan)?;
-                Some(ast::BranchDst::Label(label))
-            }
+            TokenKind::LessThan => Some(ast::BranchDst::Label(parse_label(p)?)),
             _ => None,
         })
     }
+}
+
+/// Since labels are essentially "quoted" values we basically allow anything between a `<` and `>`.
+fn parse_label(p: &mut Parser) -> Result<ast::Ident, Error> {
+    p.expect(TokenKind::LessThan)?;
+    let label_token = p.next();
+    if matches!(label_token.kind, TokenKind::GreaterThan | TokenKind::Eof) {
+        return Err(p.error("expected label name"));
+    }
+    let label = ast::Ident(p.intern_token(label_token));
+    p.expect(TokenKind::GreaterThan)?;
+    Ok(label)
 }
 
 impl Parse for ast::JumpLabel {
@@ -1401,12 +1450,6 @@ fn parse_pcode_term(p: &mut Parser) -> Result<ast::PcodeExpr, Error> {
         TokenKind::Tilde => return prefix_op!(TokenKind::Tilde, "~"),
         TokenKind::Minus => return prefix_op!(TokenKind::Minus, "-"),
         TokenKind::FMinus => return prefix_op!(TokenKind::FMinus, "f-"),
-        TokenKind::Ident => {
-            if p.check_nth(1, TokenKind::LeftParen) {
-                return Ok(ast::PcodeExpr::Call(p.parse()?));
-            }
-            ast::PcodeExpr::Ident { value: p.parse()? }
-        }
         TokenKind::Number => ast::PcodeExpr::Integer { value: p.parse()? },
         TokenKind::LeftParen => {
             p.expect(TokenKind::LeftParen)?;
@@ -1415,14 +1458,24 @@ fn parse_pcode_term(p: &mut Parser) -> Result<ast::PcodeExpr, Error> {
             inner
         }
         _ => {
-            use TokenKind::*;
-            return Err(Error {
-                message: "Error parsing: Pcode terminal expression".to_string(),
-                span: Span::new(token.span, p.current_span()),
-                cause: Some(Box::new(
-                    p.error_unexpected(token, &[Ampersand, Star, Minus, Ident, Number, LeftParen]),
-                )),
-            });
+            let Some(ident) = parse_ident_or_keyword(p)?
+            else {
+                use TokenKind::*;
+                return Err(Error {
+                    message: "Error parsing: Pcode terminal expression".to_string(),
+                    span: Span::new(token.span, p.current_span()),
+                    cause: Some(Box::new(p.error_unexpected(token, &[
+                        Ampersand, Star, Minus, Ident, Number, LeftParen,
+                    ]))),
+                });
+            };
+            match p.peek().kind {
+                TokenKind::LeftParen => {
+                    let args = parse_call_args(p)?;
+                    ast::PcodeExpr::Call(ast::PcodeCall { name: ident, args })
+                }
+                _ => ast::PcodeExpr::Ident { value: ident },
+            }
         }
     };
 
@@ -1445,13 +1498,6 @@ impl Parse for ast::DisasmAction {
 
     fn try_parse(p: &mut Parser) -> Result<Option<Self>, Error> {
         Ok(match p.peek().kind {
-            TokenKind::Ident => {
-                let ident = p.parse()?;
-                p.expect(TokenKind::Equal)?;
-                let expr = parse_disasm_expr(p)?;
-                p.expect(TokenKind::SemiColon)?;
-                Some(ast::DisasmAction::Assignment { ident, expr })
-            }
             TokenKind::GlobalSet => {
                 p.expect(TokenKind::GlobalSet)?;
                 p.expect(TokenKind::LeftParen)?;
@@ -1462,7 +1508,15 @@ impl Parse for ast::DisasmAction {
                 p.expect(TokenKind::SemiColon)?;
                 Some(ast::DisasmAction::GlobalSet { start_sym, context_sym })
             }
-            _ => None,
+            _ => match parse_ident_or_keyword(p)? {
+                Some(ident) => {
+                    p.expect(TokenKind::Equal)?;
+                    let expr = parse_disasm_expr(p)?;
+                    p.expect(TokenKind::SemiColon)?;
+                    Some(ast::DisasmAction::Assignment { ident, expr })
+                }
+                _ => None,
+            },
         })
     }
 }
@@ -1537,7 +1591,6 @@ fn parse_pattern_expr_b(
 fn parse_disasm_term(p: &mut Parser, allow_symbols: bool) -> Result<ast::PatternExpr, Error> {
     let token = p.peek();
     match token.kind {
-        TokenKind::Ident => Ok(ast::PatternExpr::Ident(p.parse()?)),
         TokenKind::Number => Ok(ast::PatternExpr::Integer(p.parse()?)),
         TokenKind::Minus => {
             p.expect(TokenKind::Minus)?;
@@ -1556,8 +1609,13 @@ fn parse_disasm_term(p: &mut Parser, allow_symbols: bool) -> Result<ast::Pattern
             Ok(inner)
         }
         _ => {
-            use TokenKind::*;
-            Err(p.error_unexpected(token, &[Ident, Number, Tilde, LeftParen]))
+            let Some(ident) = parse_ident_or_keyword(p)?
+            else {
+                use TokenKind::*;
+                return Err(p.error_unexpected(token, &[Ident, Number, Tilde, LeftParen]));
+            };
+
+            Ok(ast::PatternExpr::Ident(ident))
         }
     }
 }

--- a/sleigh/sleigh-runtime/src/const_eval.rs
+++ b/sleigh/sleigh-runtime/src/const_eval.rs
@@ -40,6 +40,7 @@ pub fn const_eval(dst: pcode::VarNode, op: pcode::Op, inputs: &pcode::Inputs) ->
             Some(a.wrapping_mul(b) & pcode::mask(size as u64 * 8))
         }
         (pcode::Op::IntAnd, [pcode::Value::Const(a, _), pcode::Value::Const(b, _)]) => Some(a & b),
+        (pcode::Op::IntOr, [pcode::Value::Const(a, _), pcode::Value::Const(b, _)]) => Some(a | b),
         (pcode::Op::IntEqual, [pcode::Value::Const(a, _), pcode::Value::Const(b, _)]) => {
             Some(if a == b { 1 } else { 0 })
         }

--- a/sleigh/sleigh-runtime/src/lifter.rs
+++ b/sleigh/sleigh-runtime/src/lifter.rs
@@ -310,6 +310,8 @@ impl<'a, 'b> LifterCtx<'a, 'b> {
                         resolved_inputs.push(self.resolve_value(*input)?);
                     }
 
+                    // Convert branch operations that target the next instruction to an internal
+                    // branch to the end of the block.
                     let inst_next = self.subtable.inst_next;
                     if matches!(op, pcode::Op::Branch(_)) && resolved_inputs[1].const_eq(inst_next)
                     {
@@ -390,7 +392,7 @@ impl<'a, 'b> LifterCtx<'a, 'b> {
                             }
                         },
                         Output::Pointer(addr, offset, size) => {
-                            self.emit_store(addr, offset, reg_ptr.slice(0, size).into())?;
+                            self.emit_store(addr, offset, reg_ptr.slice(0, size))?;
                         }
                     }
                 }
@@ -400,7 +402,7 @@ impl<'a, 'b> LifterCtx<'a, 'b> {
                     match self.get_runtime_value(reg_ptr)? {
                         pcode::Value::Const(offset, _) => {
                             let var = VarNode::register(offset as u32, *size);
-                            self.emit_copy(value, var.into())?
+                            self.emit_copy(value, var)?
                         }
                         reg => {
                             let value = self.get_runtime_value(value)?;
@@ -454,7 +456,7 @@ impl<'a, 'b> LifterCtx<'a, 'b> {
 
         match self.subtable.data.map_sleigh_reg(var.offset, var.size as u8) {
             Some((reg, offset)) => {
-                reg.get_var(offset, size).ok_or(Error::UnknownVarNode(var.offset, size))
+                reg.slice_var(offset, size).ok_or(Error::UnknownVarNode(var.offset, size))
             }
             None => Err(Error::UnknownVarNode(var.offset, size)),
         }
@@ -506,6 +508,10 @@ impl<'a, 'b> LifterCtx<'a, 'b> {
             Local::InstNext => constant!(self.subtable.inst.inst_next),
             Local::Register(id) => {
                 let base = &self.subtable.data.named_registers[id as usize];
+
+                #[allow(deprecated)]
+                // We are deriving a new VarNode from the offset (which avoids the issues with using
+                // var directly).
                 VarNode::register(base.offset, base.var.size as u16)
                     .slice(value_offset, value_size)
                     .into()


### PR DESCRIPTION
Improves SLEIGH compatibility by:

- Improving scoping of labels within macros.
- Improving register mappings to allow for overlapping registers larger than 128 bits to be defined.
- Allowing contextual keywords to used as identifiers in certain places in the SLEIGH parser.
- Support custom defines in `sleigh-compile` to simplify emulator specific patches.
- Adds new helper functions for implementing various pcodeops found in the ARM specification.
- Fix issue where never taken branches where handled incorrectly when optimizations are disabled.


**Deprecation warning:**

Use of the `var` field in the `NamedRegister` (e.g., `cpu.arch.sleigh.get_reg("SR").unwrap().var`) is considered deprecated, the `get_varnode` method should be used instead (e.g.,  `cpu.arch.sleigh.get_varnode("SR").var`). This is necessary to better support registers larger than 128-bits.

Fixes: #72