### PR TITLE
Add proper globalset subtable support (#84).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ version = "0.3.0"
 name = "sleigh-runtime"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "pcode",
  "sleigh-parse",
 ]

--- a/icicle-cpu/src/lifter/mod.rs
+++ b/icicle-cpu/src/lifter/mod.rs
@@ -79,10 +79,6 @@ impl InstructionLifter {
         self.decoder.global_context = context;
     }
 
-    pub fn set_allow_any_addr_globalsets(&mut self, allow: bool) {
-        self.decoder.allow_any_addr_globalsets = allow;
-    }
-
     /// Lift a single instruction starting at `vaddr` returning the address of the next instruction,
     /// or `None` if no instruction could be fetched from `vaddr`.
     pub fn lift<S>(&mut self, src: &mut S, vaddr: u64) -> Result<u64, DecodeError>

--- a/icicle-cpu/src/lifter/mod.rs
+++ b/icicle-cpu/src/lifter/mod.rs
@@ -79,6 +79,10 @@ impl InstructionLifter {
         self.decoder.global_context = context;
     }
 
+    pub fn set_allow_any_addr_globalsets(&mut self, allow: bool) {
+        self.decoder.allow_any_addr_globalsets = allow;
+    }
+
     /// Lift a single instruction starting at `vaddr` returning the address of the next instruction,
     /// or `None` if no instruction could be fetched from `vaddr`.
     pub fn lift<S>(&mut self, src: &mut S, vaddr: u64) -> Result<u64, DecodeError>

--- a/icicle-test/tests/arm.ins
+++ b/icicle-test/tests/arm.ins
@@ -265,3 +265,9 @@
     // Q value computed incorrectly (result of SignedSaturate passed to SignedDoesSaturate instead of original result)
     // r2 = 0x7fffffff, lr = 1 => r2 = 0x7fffffff, Q = 1;
 }
+
+// BLX in thumb mode
+0x70096b12|1 [00 f0 c2 e8] "blx 0x70096c98"
+{
+    pc = 0x70096b12, TB = 1 => pc = 0x70096c98, TB = 0;
+}

--- a/icicle-test/tests/pcode/arm
+++ b/icicle-test/tests/pcode/arm
@@ -726,3 +726,10 @@ qadd r2,r2,lr
 	Q = SignedDoesSaturate($U1:4, 0x20:2)
 	r2 = $U1:4
 
+blx 0x70096c98
+<L0> (entry=0x70096b12):
+	lr = 0x70096b17:4
+	ISAModeSwitch = 0x0:1
+	TB = 0x0:1
+	call 0x70096c98:4
+

--- a/sleigh/sleigh-compile/src/constructor/mod.rs
+++ b/sleigh/sleigh-compile/src/constructor/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     symbols::{Attachment, SymbolKind, SymbolTable, TableId},
 };
 
+pub(crate) use self::disasm_actions::ContextAction;
 pub use self::semantics::Semantics;
 
 mod display;

--- a/sleigh/sleigh-compile/src/lib.rs
+++ b/sleigh/sleigh-compile/src/lib.rs
@@ -2,8 +2,9 @@ use std::{collections::HashMap, path::Path};
 
 use sleigh_parse::{Parser, ast};
 use sleigh_runtime::{
-    AttachmentIndex, Constructor, ConstructorDebugInfo, DecodeAction, DisplaySegment,
-    NamedRegister, RegisterAlias, RegisterAttachment, SleighData, StrIndex,
+    AttachmentIndex, Constructor, ConstructorDebugInfo, ContextModValue, DecodeAction,
+    DisplaySegment, GlobalSetAddr, NamedRegister, PatternExprOp, RegisterAlias, RegisterAttachment,
+    SleighData, StrIndex,
 };
 
 pub use sleigh_parse::resolve_dependencies;
@@ -384,19 +385,36 @@ fn add_constructor(
     let fields_end = ctx.data.fields.len() as u32;
 
     let decode_actions_start = ctx.data.decode_actions.len() as u32;
-    for (field, expr) in &constructor.disasm_actions.context_mod {
-        let start = ctx.data.context_disasm_expr.len() as u32;
-        ctx.data.context_disasm_expr.extend_from_slice(expr);
-        let end = ctx.data.context_disasm_expr.len() as u32;
-        ctx.data.decode_actions.push(DecodeAction::ModifyContext(*field, (start, end)));
-    }
 
-    for (context_id, expr) in &constructor.disasm_actions.global_set {
-        let field = symbols.context_fields[*context_id as usize].field;
-        let start = ctx.data.context_disasm_expr.len() as u32;
-        ctx.data.context_disasm_expr.extend_from_slice(expr);
-        let end = ctx.data.context_disasm_expr.len() as u32;
-        ctx.data.decode_actions.push(DecodeAction::SaveContext(field, (start, end)));
+    // Process context actions in order - this is important for correct semantics
+    // e.g., [loopEnd=1; globalset(..., loopEnd); loopEnd=0;] must capture loopEnd=1
+    for action in &constructor.disasm_actions.context_actions {
+        match action {
+            constructor::ContextAction::Modify(field, value) => {
+                let start = ctx.data.context_disasm_expr.len() as u32;
+                ctx.data.context_disasm_expr.extend_from_slice(value);
+                let end = ctx.data.context_disasm_expr.len() as u32;
+                ctx.data.decode_actions.push(DecodeAction::ModifyContext(*field, (start, end)));
+            }
+            constructor::ContextAction::GlobalSet(context_id, value) => {
+                let field = symbols.context_fields[*context_id as usize].field;
+
+                // Determine the address source for the globalset
+                let addr = if let [PatternExprOp::Value(ContextModValue::Subtable(subtable_idx))] =
+                    value.as_slice()
+                {
+                    // Subtable address - resolved after eval_disasm_expr
+                    GlobalSetAddr::Subtable(*subtable_idx)
+                } else {
+                    // Expression address - can be evaluated during decode
+                    let start = ctx.data.context_disasm_expr.len() as u32;
+                    ctx.data.context_disasm_expr.extend_from_slice(value);
+                    let end = ctx.data.context_disasm_expr.len() as u32;
+                    GlobalSetAddr::Expr((start, end))
+                };
+                ctx.data.decode_actions.push(DecodeAction::SaveContext(field, addr));
+            }
+        }
     }
 
     for action in &constructor.decode_actions {

--- a/sleigh/sleigh-parse/src/ast.rs
+++ b/sleigh/sleigh-parse/src/ast.rs
@@ -362,7 +362,7 @@ impl std::fmt::Display for ConstraintOp {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DisasmAction {
     Assignment { ident: Ident, expr: PatternExpr },
-    GlobalSet { expr: PatternExpr, context_sym: Ident },
+    GlobalSet { addr_sym: Ident, context_sym: Ident },
 }
 
 impl ParserDisplay for DisasmAction {
@@ -371,8 +371,8 @@ impl ParserDisplay for DisasmAction {
             Self::Assignment { ident, expr } => {
                 write!(f, "{} = {}", ident.display(p), expr.display(p))
             }
-            Self::GlobalSet { expr, context_sym } => {
-                write!(f, "globalset({}, {})", expr.display(p), context_sym.display(p))
+            Self::GlobalSet { addr_sym, context_sym } => {
+                write!(f, "globalset({}, {})", addr_sym.display(p), context_sym.display(p))
             }
         }
     }

--- a/sleigh/sleigh-parse/src/parser.rs
+++ b/sleigh/sleigh-parse/src/parser.rs
@@ -1501,12 +1501,12 @@ impl Parse for ast::DisasmAction {
             TokenKind::GlobalSet => {
                 p.expect(TokenKind::GlobalSet)?;
                 p.expect(TokenKind::LeftParen)?;
-                let expr = parse_disasm_expr(p)?;
+                let addr_sym = p.parse()?;
                 p.expect(TokenKind::Comma)?;
                 let context_sym = p.parse()?;
                 p.expect(TokenKind::RightParen)?;
                 p.expect(TokenKind::SemiColon)?;
-                Some(ast::DisasmAction::GlobalSet { expr, context_sym })
+                Some(ast::DisasmAction::GlobalSet { addr_sym, context_sym })
             }
             _ => match parse_ident_or_keyword(p)? {
                 Some(ident) => {

--- a/sleigh/sleigh-runtime/Cargo.toml
+++ b/sleigh/sleigh-runtime/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 pcode = { path = "../pcode" }
 sleigh-parse = { path = "../sleigh-parse" }
+ahash = { workspace = true }

--- a/sleigh/sleigh-runtime/src/lib.rs
+++ b/sleigh/sleigh-runtime/src/lib.rs
@@ -272,6 +272,16 @@ pub enum EvalKind {
     TokenField(Token, Field),
 }
 
+/// The address source for a globalset operation.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum GlobalSetAddr {
+    /// Address computed from a pattern expression (can be evaluated during decode).
+    Expr(PatternExprRange),
+    /// Address comes from a subtable's export (resolved after eval_disasm_expr).
+    /// The u32 is the local subtable index.
+    Subtable(u32),
+}
+
 /// An action for the decoder to perform.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum DecodeAction {
@@ -279,7 +289,7 @@ pub enum DecodeAction {
     ModifyContext(Field, PatternExprRange),
 
     /// Globally saves a context value.
-    SaveContext(Field, PatternExprRange),
+    SaveContext(Field, GlobalSetAddr),
 
     /// Evaluate the current value of a field and store it into a local.
     Eval(LocalIndex, EvalKind),

--- a/sleigh/sleigh-runtime/src/lib.rs
+++ b/sleigh/sleigh-runtime/src/lib.rs
@@ -275,8 +275,10 @@ pub enum EvalKind {
 /// The address source for a globalset operation.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum GlobalSetAddr {
-    /// Address computed from a pattern expression (can be evaluated during decode).
-    Expr(PatternExprRange),
+    /// Address is inst_start (current instruction address).
+    InstStart,
+    /// Address is inst_next (address after current instruction).
+    InstNext,
     /// Address comes from a subtable's export (resolved after eval_disasm_expr).
     /// The u32 is the local subtable index.
     Subtable(u32),

--- a/sleigh/sleigh-runtime/src/lib.rs
+++ b/sleigh/sleigh-runtime/src/lib.rs
@@ -38,8 +38,6 @@ pub struct RuntimeConfig {
     pub ignore_delay_slots: bool,
     /// Controls whether backtracking is allowed during constructor matching.
     pub allow_backtracking: bool,
-    /// Whether `globalset` operations other than `instr_next` are applied.
-    pub allow_any_addr_globalsets: bool,
     /// Controls whether the runtime context value will be updated as a result of `globalset`
     /// actions during instruction decoding.
     pub update_context: bool,
@@ -51,7 +49,6 @@ impl Default for RuntimeConfig {
             context: 0,
             ignore_delay_slots: false,
             allow_backtracking: true,
-            allow_any_addr_globalsets: false,
             update_context: true,
         }
     }
@@ -75,7 +72,6 @@ impl Runtime {
         let mut decoder = Decoder::new();
         decoder.allow_backtracking = config.allow_backtracking;
         decoder.ignore_delay_slots = config.ignore_delay_slots;
-        decoder.allow_any_addr_globalsets = config.allow_any_addr_globalsets;
 
         Self {
             context: config.context,


### PR DESCRIPTION
- Restores the original behavior prior to https://github.com/icicle-emu/icicle-emu/commit/a547520d1fda8c519be5d38883555bcd31316472 where the `addr` field in `globalset` isn't evaluated unless `allow_any_addr_globalsets` is set. Currently, globalsets with subtables will cause decode errors.
- Adds support for evaluating subtables in `globalset` commands if `allow_any_addr_globalsets` is set.

This should close out #84.