### PR TITLE
Fix JIT breakpoint handling in add_breakpoint and recompile

### DIFF
--- a/icicle-jit/src/lib.rs
+++ b/icicle-jit/src/lib.rs
@@ -236,7 +236,12 @@ impl JIT {
             }
             self.active[Self::lookup_key(addr)] = (addr, jit_fn);
         }
+        let group_id = self.compiled.len();
         self.compiled.push(target.entry_points().collect());
+
+        for &block_id in target.targets {
+            self.block_mapping.insert(block_id, group_id);
+        }
 
         Ok(())
     }

--- a/icicle-vm/src/lib.rs
+++ b/icicle-vm/src/lib.rs
@@ -949,12 +949,14 @@ impl Vm {
             return false;
         }
 
-        for block in self.code.blocks.iter_mut().filter(|x| x.start <= addr && addr < x.end) {
-            block.breakpoints += 1;
+        for (id, block) in self.code.blocks.iter_mut().enumerate() {
+            if block.start <= addr && addr < block.end {
+                block.breakpoints += 1;
+                // Invalidate the entire compilation group so that superblocks containing
+                // this block are removed from entry_points (not just the fast lookup).
+                self.jit.invalidate(id);
+            }
         }
-
-        // Superblocks may be keyed by a different block's address, so clear everything.
-        self.jit.clear_fast_lookup();
 
         true
     }

--- a/icicle-vm/src/lib.rs
+++ b/icicle-vm/src/lib.rs
@@ -746,6 +746,10 @@ impl Vm {
                 if !visited.insert(id) || id < self.recompile_offset {
                     continue;
                 }
+                // Don't chain breakpointed blocks into superblocks.
+                if block.breakpoints > 0 {
+                    continue;
+                }
                 compilation_group.push(id);
 
                 let mut add_target = |target: &lifter::Target| match target {
@@ -947,9 +951,10 @@ impl Vm {
 
         for block in self.code.blocks.iter_mut().filter(|x| x.start <= addr && addr < x.end) {
             block.breakpoints += 1;
-            // Make sure that any JIT blocks containing this address are removed from fast lookup.
-            self.jit.remove_fast_lookup(block.start);
         }
+
+        // Superblocks may be keyed by a different block's address, so clear everything.
+        self.jit.clear_fast_lookup();
 
         true
     }


### PR DESCRIPTION
Bug 1: When recompile groups two blocks A,B and add_breakpoint is called, JIT tries to remove JIT lookup at B.start but leaves signature at A.start. Fix by just clearing fast lookup outside the loop after every breakpoint is computed.

Bug 2: When icicle calls recompile it doesnt check for breakpoints when building compilation groups and can group a block with breakpoints into a superblock which will skip breakpoints for the same reason mentioned above. Fix by skipping recompile for blocks that already have breakpoints