### PR TITLE
Fix out-of-bounds panic in check_ident on wordsize= specs

### DIFF
--- a/sleigh/sleigh-parse/src/parser.rs
+++ b/sleigh/sleigh-parse/src/parser.rs
@@ -326,7 +326,7 @@ impl Parser {
         if next.kind != TokenKind::Ident {
             return false;
         }
-        self.interner.get((next.span.start, next.span.end)) == name
+        self.get_str(next) == name
     }
 
     /// Expands the token stream associated with `src` at the current location


### PR DESCRIPTION
Parsing any SLEIGH spec with a `wordsize=` clause on a `define space` panics the parser with an out-of-bounds slice. This affects real Ghidra specs including Toy and RISCV.

## Repro

A two-line spec is enough:

```
define endian=little;
define space ram type=ram_space size=4 wordsize=1 default;
```

```
thread 'main' panicked at sleigh/sleigh-parse/src/parser.rs:63:22:
byte index 61 is out of bounds of `ICICLElittleramtyperam_spacesize`
```

## Cause

`Parser::check_ident` (parser.rs) compares the lookahead identifier against a name by calling `self.interner.get((next.span.start, next.span.end))`. But `next.span` holds byte offsets into the source file text, whereas `Interner::get` slices the interner's separate concatenated string buffer. The two are unrelated coordinate systems, so once a source offset exceeds the interner buffer length the slice panics.

This is reached from `Space::try_parse` when it probes for the optional `wordsize` clause: `wordsize` is contextual and lexed as an `Ident`, so it passes the kind guard and hits the bad slice. Specs without `wordsize=` (for example ARM, whose next token is the `default` keyword) never reach it, which is why the crash looks arch-specific.

## Fix

Use the existing `get_str(token)` accessor, which slices the correct source content:

```rust
-        self.interner.get((next.span.start, next.span.end)) == name
+        self.get_str(next) == name
```

Behavior-preserving for specs that already parsed, and correct for the ones that panicked. Verified that the minimal repro and Toy/RISCV no longer panic (they now return ordinary `Result` values) and that ARM still compiles unchanged.