### PR TITLE
icicle-cpu: key the disassembly-change check by (vaddr, isa_mode)

### DIFF
--- a/icicle-cpu/src/lib.rs
+++ b/icicle-cpu/src/lib.rs
@@ -41,6 +41,7 @@ pub struct BlockTable {
     pub map: HashMap<BlockKey, BlockGroup>,
     pub blocks: Vec<lifter::Block>,
     pub disasm: HashMap<u64, String>,
+    pub disasm_by_mode: HashMap<BlockKey, String>,
     pub breakpoints: HashSet<u64>,
     pub modified: HashSet<usize>,
 }
@@ -50,6 +51,7 @@ impl BlockTable {
         self.map.clear();
         self.blocks.clear();
         self.disasm.clear();
+        self.disasm_by_mode.clear();
         self.modified.clear();
     }
 

--- a/icicle-cpu/src/lifter/mod.rs
+++ b/icicle-cpu/src/lifter/mod.rs
@@ -20,11 +20,16 @@ pub trait InstructionSource {
     fn arch(&self) -> &Arch;
     fn read_bytes(&mut self, vaddr: u64, buf: &mut [u8]);
     fn ensure_exec(&mut self, vaddr: u64, size: usize) -> bool;
+    fn isa_mode(&self) -> u8;
 }
 
 impl InstructionSource for crate::Cpu {
     fn arch(&self) -> &Arch {
         &self.arch
+    }
+
+    fn isa_mode(&self) -> u8 {
+        crate::Cpu::isa_mode(self)
     }
 
     fn read_bytes(&mut self, vaddr: u64, buf: &mut [u8]) {
@@ -681,13 +686,15 @@ impl BlockLifter {
 
         if self.instruction_lifter.generate_disassembly {
             let new_disasm = &self.instruction_lifter.disasm;
-            match ctx.code.disasm.entry(ctx.vaddr) {
+            let key = crate::BlockKey { vaddr: ctx.vaddr, isa_mode: ctx.src.isa_mode() as u64 };
+            match ctx.code.disasm_by_mode.entry(key) {
                 std::collections::hash_map::Entry::Occupied(old) => {
                     let old_disasm = old.get();
                     if old_disasm != new_disasm {
                         tracing::error!(
-                            "disassembly changed at {:#0x} (from {old_disasm} to {new_disasm})",
-                            ctx.vaddr
+                            "disassembly changed at {:#0x} (mode {}, from {old_disasm} to {new_disasm})",
+                            ctx.vaddr,
+                            key.isa_mode
                         );
                         return Err(DecodeError::DisassemblyChanged);
                     }
@@ -696,6 +703,7 @@ impl BlockLifter {
                     slot.insert(new_disasm.clone());
                 }
             }
+            ctx.code.disasm.entry(ctx.vaddr).or_insert_with(|| new_disasm.clone());
         }
 
         self.current.context = self.instruction_lifter.decoder.global_context;

--- a/icicle-cpu/src/utils.rs
+++ b/icicle-cpu/src/utils.rs
@@ -208,6 +208,10 @@ impl crate::lifter::InstructionSource for BasicInstructionSource {
         &self.arch
     }
 
+    fn isa_mode(&self) -> u8 {
+        0
+    }
+
     fn read_bytes(&mut self, vaddr: u64, buf: &mut [u8]) {
         buf.fill(0);
         match self.get_mem_region(vaddr, buf.len()) {

--- a/icicle-vm/src/tests.rs
+++ b/icicle-vm/src/tests.rs
@@ -142,3 +142,32 @@ fn build_riscv64() {
 fn build_x86_64() {
     let _ = crate::build(&Config::from_target_triple("x86_64-none")).unwrap();
 }
+
+#[test]
+fn disasm_change_check_distinguishes_isa_modes() {
+    // The same bytes decode differently per instruction-set mode: `0x00000000` is `andeq r0,r0,r0`
+    // in ARM and `movs r0,r0` in Thumb. On interworking targets one address can legitimately be
+    // lifted in both modes, so the disassembly-change check keeps its baseline per (vaddr,
+    // isa_mode) and does not treat the second decode as self-modifying code. Lift a padding address
+    // in Thumb then ARM and confirm the second lift is accepted.
+    let mut vm = crate::build(&Config {
+        triple: "arm".parse().unwrap(),
+        enable_shadow_stack: false,
+        ..Config::default()
+    })
+    .unwrap();
+
+    let addr = 0x1000;
+    vm.cpu.mem.map_memory_len(addr, 0x1000, Mapping { perm: perm::NONE, value: 0 });
+    vm.cpu.mem.write_bytes(addr, &[0u8; 0x1000], perm::NONE).unwrap();
+    vm.cpu.mem.update_perm(addr, 0x1000, perm::READ | perm::INIT | perm::EXEC).unwrap();
+
+    vm.cpu.set_isa_mode(1);
+    assert!(vm.lift(addr).is_ok(), "thumb lift of padding should succeed");
+
+    vm.cpu.set_isa_mode(0);
+    assert!(
+        vm.lift(addr).is_ok(),
+        "arm lift of the same padding must not be flagged as self-modifying code"
+    );
+}


### PR DESCRIPTION
The decode-time self-modifying-code check compares the cached disassembly string for an address against a fresh lift and raises DisassemblyChanged (-> SelfModifyingCode) on a mismatch. It was keyed by virtual address alone, but the same bytes decode differently per instruction-set mode: erased-flash padding lifts as `andeq r0,r0,r0` in ARM and `movs r0,r0` in Thumb at the same address. When a corrupted branch switches the core to ARM state (interworking off a bit-0-clear target) and the same padding address is re-lifted in the other mode across a warm translation cache, the check saw a "change" that was never a byte change and raised a phantom self-modifying-code crash.