### PR TITLE
Fix ARM thumb mode after Ghidra 12.1 SLEIGH update

### DIFF
--- a/icicle-vm/src/builder.rs
+++ b/icicle-vm/src/builder.rs
@@ -50,7 +50,13 @@ pub fn build_with_path(config: &Config, processors: &Path) -> Result<Vm, BuildEr
         .add_custom_reg("NEXT_PC", 8)
         .ok_or(BuildError::SpecCompileError("failed to add varnode for `NEXT_PC`".into()))?;
 
-    let reg_isa_mode = lang.sleigh.get_varnode("ISAModeSwitch");
+    // Ghidra 12.1 removed the ISAModeSwitch register from the ARM SLEIGH spec and replaced
+    // it with a .pspec alias (TB -> ISAModeSwitch). Since we don't parse .pspec register_data
+    // aliases, fall back to the underlying TB register.
+    let reg_isa_mode = lang
+        .sleigh
+        .get_varnode("ISAModeSwitch")
+        .or_else(|| lang.sleigh.get_varnode("TB"));
 
     // Set initial context values for architectures that support mode switching.
     //


### PR DESCRIPTION
Ghidra 12.1 removed the `ISAModeSwitch` register definition from `ARM.sinc` and replaced it with a `.pspec` register_data alias (`<register name="TB" alias="ISAModeSwitch"/>`). Since icicle's ldef parser does not process `.pspec` register_data aliases, `get_varnode("ISAModeSwitch")` now returns `None`, leaving `reg_isa_mode` unset. This made `set_isa_mode`/`isa_mode` no-ops, breaking all ARM thumb mode execution.

Fall back to the underlying `TB` register when `ISAModeSwitch` is not found.